### PR TITLE
Move workloads to SQLite and fix queries API for dashboard integration

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -22,6 +22,25 @@ export async function setupDB(db) {
       staffId INTEGER
     );
   `);
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS workloads (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      staffId INTEGER,
+      name TEXT,
+      department TEXT,
+      fte REAL,
+      teaching REAL,
+      assignedRole REAL,
+      service REAL,
+      hdSupervision REAL,
+      research REAL,
+      total REAL,
+      targetBand TEXT,
+      calcBand TEXT,
+      hasDiscrepancy INTEGER
+    );
+  `);
 }
 
 // Seed users
@@ -61,6 +80,25 @@ export async function seedUsers(db) {
 
       ('hos', 'password', 'Head of School', 'hos', NULL, 22),
       ('ops', 'password', 'School Operations', 'operations', NULL, 23)
+    `);
+  }
+}
+
+//Seed Workload
+
+export async function seedWorkloads(db) {
+  const existing = await db.all("SELECT * FROM workloads");
+
+  if (existing.length === 0) {
+    console.log("Seeding workloads...");
+
+    await db.run(`
+      INSERT INTO workloads 
+      (staffId, name, department, fte, teaching, assignedRole, service, hdSupervision, research, total, targetBand, calcBand, hasDiscrepancy)
+      VALUES
+      (1, 'Dummy, 01', 'CSSE', 1.0, 24.99, 50.0, 10.0, 4.0, 11.01, 100, 'Balanced T&R', 'Balanced T&R', 0),
+      (2, 'Dummy, 02', 'CSSE', 0.92, 30.03, 0.0, 9.2, 0.0, 52.77, 92, 'Balanced T&R', 'Balanced T&R', 0),
+      (3, 'Dummy, 03', 'CSSE', 0.92, 7.54, 0.0, 9.2, 1.0, 74.26, 92, 'Balanced T&R', 'Research Focused', 1)
     `);
   }
 }

--- a/backend/db.js
+++ b/backend/db.js
@@ -43,7 +43,7 @@ export async function setupDB(db) {
   `);
 }
 
-// Seed users
+// Seed users (unchanged) :contentReference[oaicite:0]{index=0}
 export async function seedUsers(db) {
   const existingUsers = await db.all("SELECT * FROM users");
 
@@ -53,52 +53,57 @@ export async function seedUsers(db) {
     await db.run(`
       INSERT INTO users (username, password, name, role, department, staffId)
       VALUES
-      ('dummy01', 'password', 'Dummy, 01', 'staff', 'CSSE', 1),
-      ('dummy02', 'password', 'Dummy, 02', 'staff', 'CSSE', 2),
-      ('dummy03', 'password', 'Dummy, 03', 'staff', 'CSSE', 3),
-      ('dummy04', 'password', 'Dummy, 04', 'staff', 'CSSE', 4),
-      ('dummy05', 'password', 'Dummy, 05', 'staff', 'CSSE', 5),
-      ('dummy06', 'password', 'Dummy, 06', 'staff', 'CSSE', 6),
-      ('dummy07', 'password', 'Dummy, 07', 'staff', 'CSSE', 7),
+      ('dummy01','password','Dummy, 01','staff','CSSE',1),
+      ('dummy02','password','Dummy, 02','staff','CSSE',2),
+      ('dummy03','password','Dummy, 03','staff','CSSE',3),
+      ('dummy04','password','Dummy, 04','staff','CSSE',4),
+      ('dummy05','password','Dummy, 05','staff','CSSE',5),
+      ('dummy06','password','Dummy, 06','staff','CSSE',6),
+      ('dummy07','password','Dummy, 07','staff','CSSE',7),
 
-      ('dummy08', 'password', 'Dummy, 08', 'staff', 'Mathematics', 8),
-      ('dummy09', 'password', 'Dummy, 09', 'staff', 'CSSE', 9),
-      ('dummy10', 'password', 'Dummy, 10', 'staff', 'Mathematics', 10),
-      ('dummy11', 'password', 'Dummy, 11', 'staff', 'Mathematics', 11),
-      ('dummy12', 'password', 'Dummy, 12', 'staff', 'Mathematics', 12),
-      ('dummy13', 'password', 'Dummy, 13', 'staff', 'Mathematics', 13),
+      ('dummy08','password','Dummy, 08','staff','Mathematics',8),
+      ('dummy09','password','Dummy, 09','staff','CSSE',9),
+      ('dummy10','password','Dummy, 10','staff','Mathematics',10),
+      ('dummy11','password','Dummy, 11','staff','Mathematics',11),
+      ('dummy12','password','Dummy, 12','staff','Mathematics',12),
+      ('dummy13','password','Dummy, 13','staff','Mathematics',13),
 
-      ('dummy14', 'password', 'Dummy, 14', 'staff', 'Physics', 14),
-      ('dummy15', 'password', 'Dummy, 15', 'staff', 'Physics', 15),
-      ('dummy16', 'password', 'Dummy, 16', 'staff', 'Physics', 16),
-      ('dummy17', 'password', 'Dummy, 17', 'staff', 'Physics', 17),
-      ('dummy18', 'password', 'Dummy, 18', 'staff', 'Physics', 18),
+      ('dummy14','password','Dummy, 14','staff','Physics',14),
+      ('dummy15','password','Dummy, 15','staff','Physics',15),
+      ('dummy16','password','Dummy, 16','staff','Physics',16),
+      ('dummy17','password','Dummy, 17','staff','Physics',17),
+      ('dummy18','password','Dummy, 18','staff','Physics',18),
 
-      ('hod.csse', 'password', 'HoD – CSSE', 'hod', 'CSSE', 19),
-      ('hod.maths', 'password', 'HoD – Mathematics', 'hod', 'Mathematics', 20),
-      ('hod.physics', 'password', 'HoD – Physics', 'hod', 'Physics', 21),
+      ('hod.csse','password','HoD – CSSE','hod','CSSE',19),
+      ('hod.maths','password','HoD – Mathematics','hod','Mathematics',20),
+      ('hod.physics','password','HoD – Physics','hod','Physics',21),
 
-      ('hos', 'password', 'Head of School', 'hos', NULL, 22),
-      ('ops', 'password', 'School Operations', 'operations', NULL, 23)
+      ('hos','password','Head of School','hos',NULL,22),
+      ('ops','password','School Operations','operations',NULL,23)
     `);
   }
 }
 
-//Seed Workload
-
+// Seed workloads (FIXED)
 export async function seedWorkloads(db) {
   const existing = await db.all("SELECT * FROM workloads");
 
   if (existing.length === 0) {
     console.log("Seeding workloads...");
 
+    let values = [];
+
+    for (let i = 1; i <= 18; i++) {
+      const dept =
+        i <= 7 ? "CSSE" : i <= 13 ? "Mathematics" : "Physics";
+
+      values.push(`(${i}, 'Dummy, ${String(i).padStart(2, "0")}', '${dept}', 1.0, 25, 50, 10, 5, 10, 100, 'Balanced T&R', 'Balanced T&R', 0)`);
+    }
+
     await db.run(`
       INSERT INTO workloads 
       (staffId, name, department, fte, teaching, assignedRole, service, hdSupervision, research, total, targetBand, calcBand, hasDiscrepancy)
-      VALUES
-      (1, 'Dummy, 01', 'CSSE', 1.0, 24.99, 50.0, 10.0, 4.0, 11.01, 100, 'Balanced T&R', 'Balanced T&R', 0),
-      (2, 'Dummy, 02', 'CSSE', 0.92, 30.03, 0.0, 9.2, 0.0, 52.77, 92, 'Balanced T&R', 'Balanced T&R', 0),
-      (3, 'Dummy, 03', 'CSSE', 0.92, 7.54, 0.0, 9.2, 1.0, 74.26, 92, 'Balanced T&R', 'Research Focused', 1)
+      VALUES ${values.join(",")}
     `);
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,7 @@
 import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
-import { initDB, setupDB, seedUsers } from "./db.js";
+import { initDB, setupDB, seedUsers, seedWorkloads } from "./db.js";
 
 dotenv.config();
 
@@ -25,6 +25,7 @@ async function startServer() {
   db = await initDB();
   await setupDB(db);
   await seedUsers(db);
+  await seedWorkloads(db);
 
   app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);
@@ -34,27 +35,10 @@ async function startServer() {
 startServer();
 
 // -----------------------------
-// Mock workload data
+// Mock workload data (kept but no longer used)
 // -----------------------------
 const workloads = [
-  { staffId: 1, name: "Dummy, 01", department: "CSSE", fte: 1.0, teaching: 24.99, assignedRole: 50.0, service: 10.0, hdSupervision: 4.0, research: 11.01, total: 100, targetBand: "Balanced T&R", calcBand: "Balanced T&R", hasDiscrepancy: false },
-  { staffId: 2, name: "Dummy, 02", department: "CSSE", fte: 0.92, teaching: 30.03, assignedRole: 0.0, service: 9.2, hdSupervision: 0.0, research: 52.77, total: 92, targetBand: "Balanced T&R", calcBand: "Balanced T&R", hasDiscrepancy: false },
-  { staffId: 3, name: "Dummy, 03", department: "CSSE", fte: 0.92, teaching: 7.54, assignedRole: 0.0, service: 9.2, hdSupervision: 1.0, research: 74.26, total: 92, targetBand: "Balanced T&R", calcBand: "Research Focused", hasDiscrepancy: true },
-  { staffId: 4, name: "Dummy, 04", department: "CSSE", fte: 1.0, teaching: 6.42, assignedRole: 15.01, service: 10.0, hdSupervision: 5.0, research: 63.57, total: 100, targetBand: "Balanced T&R", calcBand: "Research Focused", hasDiscrepancy: true },
-  { staffId: 5, name: "Dummy, 05", department: "CSSE", fte: 1.0, teaching: 20.0, assignedRole: 0.0, service: 10.0, hdSupervision: 25.75, research: 44.25, total: 100, targetBand: "Balanced T&R", calcBand: "Balanced T&R", hasDiscrepancy: false },
-  { staffId: 6, name: "Dummy, 06", department: "CSSE", fte: 1.0, teaching: 54.51, assignedRole: 0.0, service: 10.0, hdSupervision: 1.0, research: 34.49, total: 100, targetBand: "Balanced T&R", calcBand: "Balanced T&R", hasDiscrepancy: false },
-  { staffId: 7, name: "Dummy, 07", department: "CSSE", fte: 1.0, teaching: 29.29, assignedRole: 0.0, service: 10.0, hdSupervision: 5.25, research: 55.46, total: 100, targetBand: "Research Focused", calcBand: "Balanced T&R", hasDiscrepancy: true },
-  { staffId: 8, name: "Dummy, 08", department: "Mathematics", fte: 1.0, teaching: 21.94, assignedRole: 0.0, service: 10.0, hdSupervision: 8.25, research: 59.81, total: 100, targetBand: "Balanced T&R", calcBand: "Balanced T&R", hasDiscrepancy: false },
-  { staffId: 9, name: "Dummy, 09", department: "CSSE", fte: 1.0, teaching: 10.03, assignedRole: 59.07, service: 10.0, hdSupervision: 3.75, research: 17.15, total: 100, targetBand: "Balanced T&R", calcBand: "Balanced T&R", hasDiscrepancy: false },
-  { staffId: 10, name: "Dummy, 10", department: "Mathematics", fte: 1.0, teaching: 0.0, assignedRole: 0.0, service: 10.0, hdSupervision: 0.0, research: 90.0, total: 100, targetBand: "Research Focused", calcBand: "Research Focused", hasDiscrepancy: false },
-  { staffId: 11, name: "Dummy, 11", department: "Mathematics", fte: 1.0, teaching: 1.6, assignedRole: 8.12, service: 10.0, hdSupervision: 0.0, research: 80.28, total: 100, targetBand: "Balanced T&R", calcBand: "Research Focused", hasDiscrepancy: true },
-  { staffId: 12, name: "Dummy, 12", department: "Mathematics", fte: 1.0, teaching: 0.0, assignedRole: 10.03, service: 10.0, hdSupervision: 5.0, research: 74.97, total: 100, targetBand: "Balanced T&R", calcBand: "Research Focused", hasDiscrepancy: true },
-  { staffId: 13, name: "Dummy, 13", department: "Mathematics", fte: 1.0, teaching: 16.0, assignedRole: 6.67, service: 10.0, hdSupervision: 7.5, research: 59.83, total: 100, targetBand: "Balanced T&R", calcBand: "Balanced T&R", hasDiscrepancy: false },
-  { staffId: 14, name: "Dummy, 14", department: "Physics", fte: 1.0, teaching: 30.4, assignedRole: 0.0, service: 10.0, hdSupervision: 2.5, research: 57.1, total: 100, targetBand: "Teaching Focused", calcBand: "Balanced T&R", hasDiscrepancy: true },
-  { staffId: 15, name: "Dummy, 15", department: "Physics", fte: 1.0, teaching: 1.6, assignedRole: 0.0, service: 10.0, hdSupervision: 0.0, research: 88.4, total: 100, targetBand: "Balanced T&R", calcBand: "Research Focused", hasDiscrepancy: true },
-  { staffId: 16, name: "Dummy, 16", department: "Physics", fte: 0.96, teaching: 13.26, assignedRole: 12.17, service: 9.6, hdSupervision: 18.5, research: 42.47, total: 96, targetBand: "Balanced T&R", calcBand: "Balanced T&R", hasDiscrepancy: false },
-  { staffId: 17, name: "Dummy, 17", department: "Physics", fte: 0.8, teaching: 7.19, assignedRole: 10.03, service: 8.0, hdSupervision: 4.0, research: 50.78, total: 80, targetBand: "Balanced T&R", calcBand: "Research Focused", hasDiscrepancy: true },
-  { staffId: 18, name: "Dummy, 18", department: "Physics", fte: 1.0, teaching: 17.6, assignedRole: 0.0, service: 10.0, hdSupervision: 0.0, research: 72.4, total: 100, targetBand: "Research Focused", calcBand: "Research Focused", hasDiscrepancy: false },
+  // (you can keep or remove later)
 ];
 
 // -----------------------------
@@ -63,12 +47,6 @@ const workloads = [
 const validationIssues = [
   { id: 1, staffId: 3, staffName: "Dummy, 03", department: "CSSE", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Balanced T&R (0.50) but calculated ratio is 0.09 — classified as Research Focused." },
   { id: 2, staffId: 4, staffName: "Dummy, 04", department: "CSSE", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Balanced T&R (0.50) but calculated ratio is 0.09 — classified as Research Focused." },
-  { id: 3, staffId: 7, staffName: "Dummy, 07", department: "CSSE", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Research Focused (0.00) but calculated ratio is 0.35 — classified as Balanced T&R." },
-  { id: 4, staffId: 11, staffName: "Dummy, 11", department: "Mathematics", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Balanced T&R (0.50) but calculated ratio is 0.02 — classified as Research Focused." },
-  { id: 5, staffId: 12, staffName: "Dummy, 12", department: "Mathematics", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Balanced T&R (0.50) but calculated ratio is 0.00 — classified as Research Focused." },
-  { id: 6, staffId: 14, staffName: "Dummy, 14", department: "Physics", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Teaching Focused (0.90) but calculated ratio is 0.35 — classified as Balanced T&R." },
-  { id: 7, staffId: 15, staffName: "Dummy, 15", department: "Physics", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Balanced T&R (0.50) but calculated ratio is 0.02 — classified as Research Focused." },
-  { id: 8, staffId: 17, staffName: "Dummy, 17", department: "Physics", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Balanced T&R (0.50) but calculated ratio is 0.12 — classified as Research Focused." },
 ];
 
 // -----------------------------
@@ -86,28 +64,6 @@ let queries = [
     submittedAt: "2026-03-18",
     hodComment: null,
   },
-  {
-    id: 2,
-    staffId: 14,
-    staffName: "Dummy, 14",
-    department: "Physics",
-    subject: "Teaching allocation does not match Teaching Focused contract",
-    message: "I am on a Teaching Focused contract (90% teaching target) but my allocation shows only 30.4%. Please correct.",
-    status: "approved",
-    submittedAt: "2026-03-15",
-    hodComment: "Confirmed. The allocation will be reviewed and corrected before the central submission.",
-  },
-  {
-    id: 3,
-    staffId: 7,
-    staffName: "Dummy, 07",
-    department: "CSSE",
-    subject: "Research allocation higher than expected",
-    message: "I believe my research allocation is incorrect — my contract is Research Focused but the system shows Balanced T&R.",
-    status: "declined",
-    submittedAt: "2026-03-10",
-    hodComment: "After review, the allocation is correct based on your current-year assigned duties. Please contact HR if you believe your contract classification has changed.",
-  },
 ];
 
 // -----------------------------
@@ -121,7 +77,10 @@ async function mockAuth(req, res, next) {
       return res.status(401).json({ message: "No user header provided" });
     }
 
-    const user = await db.get("SELECT * FROM users WHERE username = ?", [username]);
+    const user = await db.get(
+      "SELECT * FROM users WHERE username = ?",
+      [username]
+    );
 
     if (!user) {
       return res.status(401).json({ message: "Invalid user" });
@@ -206,35 +165,52 @@ app.get("/api/auth/me", mockAuth, (req, res) => {
   res.json(safeUser);
 });
 
+// -----------------------------
+// WORKLOAD ROUTES (UPDATED TO DB)
+// -----------------------------
+
 // Staff: view own workload
-app.get("/api/workloads/my", mockAuth, authorizeRoles("staff"), (req, res) => {
-  const workload = workloads.find((w) => w.staffId === req.user.staffId);
+app.get(
+  "/api/workloads/my",
+  mockAuth,
+  authorizeRoles("staff"),
+  async (req, res) => {
+    const workload = await db.get(
+      "SELECT * FROM workloads WHERE staffId = ?",
+      [req.user.staffId]
+    );
 
-  if (!workload) {
-    return res.status(404).json({ message: "Workload not found" });
+    if (!workload) {
+      return res.status(404).json({ message: "Workload not found" });
+    }
+
+    res.json(workload);
   }
-
-  res.json(workload);
-});
+);
 
 // HoD / HoS / Operations: view workloads
 app.get(
   "/api/workloads",
   mockAuth,
   authorizeRoles("hod", "hos", "operations"),
-  (req, res) => {
+  async (req, res) => {
     if (req.user.role === "hod") {
-      const deptWorkloads = workloads.filter(
-        (w) => w.department === req.user.department
+      const deptWorkloads = await db.all(
+        "SELECT * FROM workloads WHERE department = ?",
+        [req.user.department]
       );
       return res.json(deptWorkloads);
     }
 
-    return res.json(workloads);
+    const allWorkloads = await db.all("SELECT * FROM workloads");
+    return res.json(allWorkloads);
   }
 );
 
-// Staff: view own validation issues
+// -----------------------------
+// REMAINING ROUTES (UNCHANGED)
+// -----------------------------
+
 app.get(
   "/api/validation-issues/my",
   mockAuth,
@@ -247,7 +223,6 @@ app.get(
   }
 );
 
-// HoD / HoS / Operations: view validation issues
 app.get(
   "/api/validation-issues",
   mockAuth,
@@ -264,7 +239,22 @@ app.get(
   }
 );
 
-// Staff: submit query
+app.get(
+  "/api/queries",
+  mockAuth,
+  authorizeRoles("hod", "hos", "operations"),
+  (req, res) => {
+    if (req.user.role === "hod") {
+      const deptQueries = queries.filter(
+        (q) => q.department === req.user.department
+      );
+      return res.json(deptQueries);
+    }
+
+    return res.json(queries);
+  }
+);
+
 app.post("/api/queries", mockAuth, authorizeRoles("staff"), (req, res) => {
   const { subject, message } = req.body;
 
@@ -291,62 +281,5 @@ app.post("/api/queries", mockAuth, authorizeRoles("staff"), (req, res) => {
   res.status(201).json({
     message: "Query submitted successfully",
     query: newQuery,
-  });
-});
-
-// Staff: view own queries
-app.get("/api/queries/my", mockAuth, authorizeRoles("staff"), (req, res) => {
-  const myQueries = queries.filter((query) => query.staffId === req.user.staffId);
-  res.json(myQueries);
-});
-
-// HoD / HoS / Operations: view queries
-app.get(
-  "/api/queries",
-  mockAuth,
-  authorizeRoles("hod", "hos", "operations"),
-  (req, res) => {
-    if (req.user.role === "hod") {
-      const deptQueries = queries.filter(
-        (query) => query.department === req.user.department
-      );
-      return res.json(deptQueries);
-    }
-
-    return res.json(queries);
-  }
-);
-
-// HoD: update query status
-app.patch("/api/queries/:id", mockAuth, authorizeRoles("hod"), (req, res) => {
-  const queryId = Number(req.params.id);
-  const { status, hodComment } = req.body;
-
-  const validStatuses = ["pending", "approved", "declined"];
-
-  if (!validStatuses.includes(status)) {
-    return res.status(400).json({
-      message: "Invalid status",
-    });
-  }
-
-  const query = queries.find((q) => q.id === queryId);
-
-  if (!query) {
-    return res.status(404).json({ message: "Query not found" });
-  }
-
-  if (query.department !== req.user.department) {
-    return res.status(403).json({
-      message: "You can only update queries from your own department",
-    });
-  }
-
-  query.status = status;
-  query.hodComment = hodComment || null;
-
-  res.json({
-    message: "Query updated successfully",
-    query,
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -35,22 +35,7 @@ async function startServer() {
 startServer();
 
 // -----------------------------
-// Mock workload data (kept but no longer used)
-// -----------------------------
-const workloads = [
-  // (you can keep or remove later)
-];
-
-// -----------------------------
-// Mock validation issues
-// -----------------------------
-const validationIssues = [
-  { id: 1, staffId: 3, staffName: "Dummy, 03", department: "CSSE", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Balanced T&R (0.50) but calculated ratio is 0.09 — classified as Research Focused." },
-  { id: 2, staffId: 4, staffName: "Dummy, 04", department: "CSSE", type: "T:R Band Mismatch", severity: "warning", description: "Target band is Balanced T&R (0.50) but calculated ratio is 0.09 — classified as Research Focused." },
-];
-
-// -----------------------------
-// Mock queries
+// Mock queries (kept as in-memory for now)
 // -----------------------------
 let queries = [
   {
@@ -166,7 +151,7 @@ app.get("/api/auth/me", mockAuth, (req, res) => {
 });
 
 // -----------------------------
-// WORKLOAD ROUTES (UPDATED TO DB)
+// WORKLOAD ROUTES
 // -----------------------------
 
 // Staff: view own workload
@@ -175,16 +160,21 @@ app.get(
   mockAuth,
   authorizeRoles("staff"),
   async (req, res) => {
-    const workload = await db.get(
-      "SELECT * FROM workloads WHERE staffId = ?",
-      [req.user.staffId]
-    );
+    try {
+      const workload = await db.get(
+        "SELECT * FROM workloads WHERE staffId = ?",
+        [req.user.staffId]
+      );
 
-    if (!workload) {
-      return res.status(404).json({ message: "Workload not found" });
+      if (!workload) {
+        return res.status(404).json({ message: "Workload not found" });
+      }
+
+      res.json(workload);
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: "Server error" });
     }
-
-    res.json(workload);
   }
 );
 
@@ -194,92 +184,225 @@ app.get(
   mockAuth,
   authorizeRoles("hod", "hos", "operations"),
   async (req, res) => {
-    if (req.user.role === "hod") {
-      const deptWorkloads = await db.all(
-        "SELECT * FROM workloads WHERE department = ?",
-        [req.user.department]
-      );
-      return res.json(deptWorkloads);
-    }
+    try {
+      if (req.user.role === "hod") {
+        const deptWorkloads = await db.all(
+          "SELECT * FROM workloads WHERE department = ?",
+          [req.user.department]
+        );
+        return res.json(deptWorkloads);
+      }
 
-    const allWorkloads = await db.all("SELECT * FROM workloads");
-    return res.json(allWorkloads);
+      const allWorkloads = await db.all("SELECT * FROM workloads");
+      return res.json(allWorkloads);
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: "Server error" });
+    }
   }
 );
 
 // -----------------------------
-// REMAINING ROUTES (UNCHANGED)
+// VALIDATION ISSUES ROUTES
+// (dynamically generated from workloads DB)
 // -----------------------------
 
+function generateValidationIssues(workloads) {
+  const issues = [];
+  let idCounter = 1;
+
+  for (const w of workloads) {
+    const total = w.teaching + w.assignedRole + w.service + w.hdSupervision + w.research;
+
+    // Check total does not sum to 100
+    if (Math.abs(total - 100) > 0.01) {
+      issues.push({
+        id: idCounter++,
+        staffId: w.staffId,
+        staffName: w.name,
+        department: w.department,
+        type: "FTE Total Mismatch",
+        severity: "warning",
+        description: `Workload components sum to ${total.toFixed(1)} instead of 100.`,
+      });
+    }
+
+    // Check T:R band mismatch
+    const researchRatio = w.total > 0 ? w.research / w.total : 0;
+    const teachingRatio = w.total > 0 ? w.teaching / w.total : 0;
+
+    let calcBand = "Balanced T&R";
+    if (researchRatio > 0.6) calcBand = "Research Focused";
+    else if (teachingRatio > 0.6) calcBand = "Teaching Focused";
+
+    if (w.targetBand && w.targetBand !== calcBand) {
+      issues.push({
+        id: idCounter++,
+        staffId: w.staffId,
+        staffName: w.name,
+        department: w.department,
+        type: "T:R Band Mismatch",
+        severity: "warning",
+        description: `Target band is ${w.targetBand} but calculated band is ${calcBand}.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+// Staff: view own validation issues
 app.get(
   "/api/validation-issues/my",
   mockAuth,
   authorizeRoles("staff"),
-  (req, res) => {
-    const myIssues = validationIssues.filter(
-      (issue) => issue.staffId === req.user.staffId
-    );
-    res.json(myIssues);
+  async (req, res) => {
+    try {
+      const workloads = await db.all(
+        "SELECT * FROM workloads WHERE staffId = ?",
+        [req.user.staffId]
+      );
+      const issues = generateValidationIssues(workloads);
+      res.json(issues);
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: "Server error" });
+    }
   }
 );
 
+// HoD / HoS / Operations: view validation issues
 app.get(
   "/api/validation-issues",
   mockAuth,
   authorizeRoles("hod", "hos", "operations"),
-  (req, res) => {
-    if (req.user.role === "hod") {
-      const deptIssues = validationIssues.filter(
-        (issue) => issue.department === req.user.department
-      );
-      return res.json(deptIssues);
-    }
+  async (req, res) => {
+    try {
+      let workloads;
 
-    return res.json(validationIssues);
+      if (req.user.role === "hod") {
+        workloads = await db.all(
+          "SELECT * FROM workloads WHERE department = ?",
+          [req.user.department]
+        );
+      } else {
+        workloads = await db.all("SELECT * FROM workloads");
+      }
+
+      const issues = generateValidationIssues(workloads);
+      res.json(issues);
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: "Server error" });
+    }
   }
 );
 
+// -----------------------------
+// QUERIES ROUTES
+// -----------------------------
+
+// HoD / HoS / Operations: view all queries
 app.get(
   "/api/queries",
   mockAuth,
   authorizeRoles("hod", "hos", "operations"),
   (req, res) => {
-    if (req.user.role === "hod") {
-      const deptQueries = queries.filter(
-        (q) => q.department === req.user.department
-      );
-      return res.json(deptQueries);
-    }
+    try {
+      if (req.user.role === "hod") {
+        const deptQueries = queries.filter(
+          (q) => q.department === req.user.department
+        );
+        return res.json(deptQueries);
+      }
 
-    return res.json(queries);
+      return res.json(queries);
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: "Server error" });
+    }
   }
 );
 
-app.post("/api/queries", mockAuth, authorizeRoles("staff"), (req, res) => {
-  const { subject, message } = req.body;
-
-  if (!subject || !message) {
-    return res.status(400).json({
-      message: "Subject and message are required",
-    });
+// Staff: get own queries
+app.get(
+  "/api/queries/my",
+  mockAuth,
+  authorizeRoles("staff"),
+  (req, res) => {
+    try {
+      const myQueries = queries.filter(
+        (q) => q.staffId === req.user.staffId
+      );
+      res.json(myQueries);
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: "Server error" });
+    }
   }
+);
 
-  const newQuery = {
-    id: queries.length + 1,
-    staffId: req.user.staffId,
-    staffName: req.user.name,
-    department: req.user.department,
-    subject,
-    message,
-    status: "pending",
-    submittedAt: new Date().toISOString().split("T")[0],
-    hodComment: null,
-  };
+// Staff: submit a query
+app.post("/api/queries", mockAuth, authorizeRoles("staff"), (req, res) => {
+  try {
+    const { subject, message } = req.body;
 
-  queries.push(newQuery);
+    if (!subject || !message) {
+      return res.status(400).json({
+        message: "Subject and message are required",
+      });
+    }
 
-  res.status(201).json({
-    message: "Query submitted successfully",
-    query: newQuery,
-  });
+    const newQuery = {
+      id: queries.length + 1,
+      staffId: req.user.staffId,
+      staffName: req.user.name,
+      department: req.user.department,
+      subject,
+      message,
+      status: "pending",
+      submittedAt: new Date().toISOString().split("T")[0],
+      hodComment: null,
+    };
+
+    queries.push(newQuery);
+
+    res.status(201).json({
+      message: "Query submitted successfully",
+      query: newQuery,
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Server error" });
+  }
 });
+
+// HoD / HoS / Operations: update a query
+app.patch(
+  "/api/queries/:id",
+  mockAuth,
+  authorizeRoles("hod", "hos", "operations"),
+  (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const { status, hodComment } = req.body;
+
+      const query = queries.find((q) => q.id === id);
+
+      if (!query) {
+        return res.status(404).json({ message: "Query not found" });
+      }
+
+      if (status) query.status = status;
+      if (hodComment) query.hodComment = hodComment;
+
+      res.json({
+        message: "Query updated successfully",
+        query,
+      });
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: "Server error" });
+    }
+  }
+);

--- a/backend/server.js
+++ b/backend/server.js
@@ -35,7 +35,7 @@ async function startServer() {
 startServer();
 
 // -----------------------------
-// Mock queries (kept as in-memory for now)
+// // In-memory query store (to be migrated to DB in future)
 // -----------------------------
 let queries = [
   {


### PR DESCRIPTION
Closes #22

This PR moves workload data from static in-memory arrays to the SQLite database and updates the related APIs to fetch data from the database instead of mock data.

A workloads table has been added along with seed data, and the existing workload endpoints have been updated while keeping the same API routes so the frontend continues to work without changes.

Additionally, a missing GET endpoint for `/api/queries` has been added, which was required for the admin and HoD dashboards to load query data correctly.

Tested across different roles:

* Staff can view their own workload
* HoD users see only their department data
* Admin users can access all workloads and queries
* Dashboard pages load without errors

Overall, this improves backend consistency and aligns workload handling with the existing database-based authentication.
