### PR TITLE
Add academic search workload pages

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,4 +1,4 @@
-import { Form, Input, Button, Card, Typography, Alert, Select } from 'antd';
+import { Form, Input, Button, Card, Typography, Alert } from 'antd';
 import { UserOutlined, LockOutlined } from '@ant-design/icons';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -14,44 +14,36 @@ const ROLE_REDIRECTS = {
   operations: '/admin/dashboard',
 };
 
-// Pre-set demo accounts for development/demo use only — all share the same password "password"
-const DEMO_ACCOUNTS = [
-  { label: 'Academic Staff – Dummy 01 (CSSE)', value: 'dummy01' },
-  { label: 'Academic Staff – Dummy 14 (Physics, T:R issue)', value: 'dummy14' },
-  { label: 'Head of Department – CSSE', value: 'hod.csse' },
-  { label: 'Head of Department – Mathematics', value: 'hod.maths' },
-  { label: 'Head of Department – Physics', value: 'hod.physics' },
-  { label: 'Head of School', value: 'hos' },
-  { label: 'School Operations', value: 'ops' },
-];
-
 /**
  * LoginPage handles user authentication.
  * - Calls AuthContext.login() which posts credentials to /api/auth/login
  * - On success, redirects to the user's role-specific default page
- * - Quick fill dropdown pre-fills credentials for demo/development use
  */
 export default function LoginPage() {
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
   const [form] = Form.useForm();
   const { login } = useAuth();
   const navigate = useNavigate();
 
-  function handleDemoSelect(username) {
-    form.setFieldsValue({ username, password: 'password' });
-    setError('');
-  }
-
   async function handleSubmit(values) {
-    setError('');
+    try {
+      setError('');
+      setLoading(true);
 
-    const result = await login(values.username, values.password);
+      const result = await login(values.username, values.password);
 
-    if (result.success) {
-      const redirect = ROLE_REDIRECTS[result.user.role] || '/';
-      navigate(redirect);
-    } else {
-      setError(result.message || 'Invalid username or password.');
+      if (result.success) {
+        const redirect = ROLE_REDIRECTS[result.user.role] || '/';
+        navigate(redirect);
+      } else {
+        setError(result.message || 'Invalid username or password.');
+      }
+    } catch (err) {
+      setError(err.message || 'Login failed. Please try again.');
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -66,7 +58,14 @@ export default function LoginPage() {
         padding: '24px',
       }}
     >
-      <Card style={{ width: '100%', maxWidth: 420, borderRadius: 12 }} variant="borderless">
+      <Card
+        style={{
+          width: '100%',
+          maxWidth: 420,
+          borderRadius: 12,
+        }}
+        variant="borderless"
+      >
         <div style={{ textAlign: 'center', marginBottom: 32 }}>
           <div
             style={{
@@ -82,46 +81,73 @@ export default function LoginPage() {
           >
             <UserOutlined style={{ fontSize: 28, color: '#fff' }} />
           </div>
+
           <Title level={3} style={{ margin: 0 }}>
             Workload Verification System
           </Title>
+
           <Text type="secondary">UWA – PMC School Operations</Text>
         </div>
 
         {error && (
-          <Alert message={error} type="error" showIcon style={{ marginBottom: 16 }} />
+          <Alert
+            message={error}
+            type="error"
+            showIcon
+            style={{ marginBottom: 16 }}
+          />
         )}
 
-        <div style={{ marginBottom: 16 }}>
-          <Text type="secondary" style={{ fontSize: 12 }}>
-            Quick fill (demo only):
-          </Text>
-          <Select
-            placeholder="Select a demo account"
-            style={{ width: '100%', marginTop: 4 }}
-            onChange={handleDemoSelect}
-            options={DEMO_ACCOUNTS}
-            allowClear
-          />
-        </div>
-
-        <Form form={form} layout="vertical" onFinish={handleSubmit} requiredMark={false}>
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={handleSubmit}
+          requiredMark={false}
+        >
           <Form.Item
+            label="Username"
             name="username"
-            rules={[{ required: true, message: 'Please enter your username.' }]}
+            rules={[
+              {
+                required: true,
+                message: 'Please enter your username.',
+              },
+            ]}
           >
-            <Input prefix={<UserOutlined />} placeholder="Username" size="large" />
+            <Input
+              prefix={<UserOutlined />}
+              placeholder="Enter username"
+              size="large"
+              autoComplete="username"
+            />
           </Form.Item>
 
           <Form.Item
+            label="Password"
             name="password"
-            rules={[{ required: true, message: 'Please enter your password.' }]}
+            rules={[
+              {
+                required: true,
+                message: 'Please enter your password.',
+              },
+            ]}
           >
-            <Input.Password prefix={<LockOutlined />} placeholder="Password" size="large" />
+            <Input.Password
+              prefix={<LockOutlined />}
+              placeholder="Enter password"
+              size="large"
+              autoComplete="current-password"
+            />
           </Form.Item>
 
           <Form.Item style={{ marginBottom: 0 }}>
-            <Button type="primary" htmlType="submit" block size="large">
+            <Button
+              type="primary"
+              htmlType="submit"
+              block
+              size="large"
+              loading={loading}
+            >
               Log In
             </Button>
           </Form.Item>

--- a/frontend/src/pages/admin/SchoolWorkloadPage.jsx
+++ b/frontend/src/pages/admin/SchoolWorkloadPage.jsx
@@ -1,155 +1,386 @@
-import { useState, useEffect } from 'react';
-import { Card, Table, Tag, Typography, Space, Select, Spin, Alert } from 'antd';
-import { useAuth } from '../../context/AuthContext';
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Card,
+  Col,
+  Input,
+  Row,
+  Select,
+  Space,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import { SearchOutlined } from "@ant-design/icons";
 
 const { Title, Text } = Typography;
 
-export default function SchoolWorkloadPage() {
-  const { currentUser } = useAuth();
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
-  const [loading, setLoading] = useState(true);
-  const [workload, setWorkload] = useState([]);
-  const [deptFilter, setDeptFilter] = useState('All');
-  const [error, setError] = useState('');
+function safeParse(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function getCurrentUser() {
+  const possibleKeys = [
+    "wvs_current_user",
+    "user",
+    "currentUser",
+    "authUser",
+    "loggedInUser",
+    "workloadUser",
+  ];
+
+  for (const key of possibleKeys) {
+    const value = localStorage.getItem(key);
+    if (!value) continue;
+
+    const parsed = safeParse(value);
+    if (parsed?.username) return parsed;
+    if (parsed?.user?.username) return parsed.user;
+  }
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    const value = localStorage.getItem(key);
+    const parsed = safeParse(value);
+
+    if (parsed?.username) return parsed;
+    if (parsed?.user?.username) return parsed.user;
+  }
+
+  return null;
+}
+
+function formatNumber(value) {
+  const number = Number(value || 0);
+  return Number.isInteger(number) ? number : number.toFixed(2);
+}
+
+function normalizeSearchText(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+export default function SchoolWorkloadPage() {
+  const [workloads, setWorkloads] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const [searchText, setSearchText] = useState("");
+  const [departmentFilter, setDepartmentFilter] = useState("all");
+
+  const currentUser = getCurrentUser();
+
+  async function loadWorkloads() {
+    try {
+      setLoading(true);
+      setError("");
+
+      if (!currentUser?.username) {
+        throw new Error("No logged-in user found.");
+      }
+
+      const response = await fetch(`${API_URL}/api/workloads`, {
+        headers: {
+          "x-user": currentUser.username,
+        },
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || "Failed to load school workloads.");
+      }
+
+      setWorkloads(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err.message || "Failed to load school workloads.");
+    } finally {
+      setLoading(false);
+    }
+  }
 
   useEffect(() => {
-    const fetchData = async () => {
-      if (!currentUser?.username) {
-        setLoading(false);
-        setError('No logged-in user found.');
-        return;
-      }
+    loadWorkloads();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-      setLoading(true);
-      setError('');
+  const departmentOptions = useMemo(() => {
+    const departments = Array.from(
+      new Set(workloads.map((item) => item.department).filter(Boolean))
+    ).sort();
 
-      try {
-        const response = await fetch(
-          `${import.meta.env.VITE_API_URL}/api/workloads`,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              'x-user': currentUser.username,
-            },
-          }
-        );
+    return [
+      { value: "all", label: "All departments" },
+      ...departments.map((department) => ({
+        value: department,
+        label: department,
+      })),
+    ];
+  }, [workloads]);
 
-        const data = await response.json();
+  const filteredWorkloads = useMemo(() => {
+    const search = searchText.trim().toLowerCase();
+    const normalizedSearch = normalizeSearchText(searchText);
 
-        if (!response.ok) {
-          throw new Error(data.message || 'Failed to load workload data.');
-        }
+    return workloads.filter((workload) => {
+      const name = String(workload.name || "").toLowerCase();
+      const normalizedName = normalizeSearchText(workload.name);
 
-        setWorkload(Array.isArray(data) ? data : []);
-      } catch (err) {
-        console.error('Failed to load workload:', err);
-        setError(err.message || 'Unable to load workload data.');
-      } finally {
-        setLoading(false);
-      }
+      const matchesName =
+        !search && !normalizedSearch
+          ? true
+          : name.includes(search) || normalizedName.includes(normalizedSearch);
+
+      const matchesDepartment =
+        departmentFilter === "all"
+          ? true
+          : workload.department === departmentFilter;
+
+      return matchesName && matchesDepartment;
+    });
+  }, [workloads, searchText, departmentFilter]);
+
+  const summary = useMemo(() => {
+    const totalStaff = filteredWorkloads.length;
+
+    const totalTeaching = filteredWorkloads.reduce(
+      (sum, item) => sum + Number(item.teaching || 0),
+      0
+    );
+
+    const totalResearch = filteredWorkloads.reduce(
+      (sum, item) => sum + Number(item.research || 0),
+      0
+    );
+
+    const discrepancyCount = filteredWorkloads.filter(
+      (item) => Number(item.hasDiscrepancy) === 1
+    ).length;
+
+    return {
+      totalStaff,
+      totalTeaching,
+      totalResearch,
+      discrepancyCount,
     };
-
-    fetchData();
-  }, [currentUser]);
-
-  const departments = ['All', ...new Set(workload.map((w) => w.department).filter(Boolean))];
-
-  const filtered =
-    deptFilter === 'All'
-      ? workload
-      : workload.filter((w) => w.department === deptFilter);
+  }, [filteredWorkloads]);
 
   const columns = [
-    { title: 'Staff Member', dataIndex: 'name', key: 'name' },
-    { title: 'Department', dataIndex: 'department', key: 'department' },
-    { title: 'FTE', dataIndex: 'fte', key: 'fte', width: 70 },
     {
-      title: 'Teaching (%)',
-      dataIndex: 'teaching',
-      key: 'teaching',
-      render: (v) => `${v}%`,
+      title: "Academic Name",
+      dataIndex: "name",
+      key: "name",
+      fixed: "left",
+      width: 230,
+      sorter: (a, b) => String(a.name || "").localeCompare(String(b.name || "")),
     },
     {
-      title: 'Research (%)',
-      dataIndex: 'research',
-      key: 'research',
-      render: (v) => `${v}%`,
+      title: "Department",
+      dataIndex: "department",
+      key: "department",
+      width: 140,
+      filters: departmentOptions
+        .filter((option) => option.value !== "all")
+        .map((option) => ({
+          text: option.label,
+          value: option.value,
+        })),
+      onFilter: (value, record) => record.department === value,
     },
     {
-      title: 'HDR (%)',
-      dataIndex: 'hdSupervision',
-      key: 'hdSupervision',
-      render: (v) => `${v}%`,
+      title: "FTE",
+      dataIndex: "fte",
+      key: "fte",
+      width: 80,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.fte || 0) - Number(b.fte || 0),
     },
     {
-      title: 'Service (%)',
-      dataIndex: 'service',
-      key: 'service',
-      render: (v) => `${v}%`,
+      title: "Teaching",
+      dataIndex: "teaching",
+      key: "teaching",
+      width: 100,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.teaching || 0) - Number(b.teaching || 0),
     },
     {
-      title: 'Total (%)',
-      dataIndex: 'total',
-      key: 'total',
-      render: (v) => `${v}%`,
+      title: "Assigned Role",
+      dataIndex: "assignedRole",
+      key: "assignedRole",
+      width: 130,
+      render: formatNumber,
+      sorter: (a, b) =>
+        Number(a.assignedRole || 0) - Number(b.assignedRole || 0),
     },
     {
-      title: 'Status',
-      dataIndex: 'hasDiscrepancy',
-      key: 'hasDiscrepancy',
-      render: (hasDiscrepancy) =>
-        hasDiscrepancy ? (
-          <Tag color="warning">T:R Discrepancy</Tag>
+      title: "Service",
+      dataIndex: "service",
+      key: "service",
+      width: 100,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.service || 0) - Number(b.service || 0),
+    },
+    {
+      title: "HDR",
+      dataIndex: "hdSupervision",
+      key: "hdSupervision",
+      width: 100,
+      render: formatNumber,
+      sorter: (a, b) =>
+        Number(a.hdSupervision || 0) - Number(b.hdSupervision || 0),
+    },
+    {
+      title: "Research",
+      dataIndex: "research",
+      key: "research",
+      width: 100,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.research || 0) - Number(b.research || 0),
+    },
+    {
+      title: "Total",
+      dataIndex: "total",
+      key: "total",
+      width: 90,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.total || 0) - Number(b.total || 0),
+    },
+    {
+      title: "Target Band",
+      dataIndex: "targetBand",
+      key: "targetBand",
+      width: 220,
+      render: (value) => value || "-",
+    },
+    {
+      title: "Calculated Band",
+      dataIndex: "calcBand",
+      key: "calcBand",
+      width: 230,
+      render: (value) => value || "-",
+    },
+    {
+      title: "Discrepancy",
+      dataIndex: "hasDiscrepancy",
+      key: "hasDiscrepancy",
+      width: 120,
+      render: (value) =>
+        Number(value) === 1 ? (
+          <Tag color="red">Yes</Tag>
         ) : (
-          <Tag color="success">Valid</Tag>
+          <Tag color="green">No</Tag>
         ),
+      filters: [
+        { text: "Has discrepancy", value: 1 },
+        { text: "No discrepancy", value: 0 },
+      ],
+      onFilter: (value, record) => Number(record.hasDiscrepancy) === value,
     },
   ];
 
-  if (loading) {
-    return (
-      <div style={{ display: 'flex', justifyContent: 'center', padding: '100px' }}>
-        <Spin size="large" tip="Loading workload..." />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <Alert
-        message="Unable to load school workload"
-        description={error}
-        type="error"
-        showIcon
-      />
-    );
-  }
-
   return (
-    <Space direction="vertical" size="large" style={{ width: '100%' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
-        <div>
-          <Title level={4} style={{ margin: 0 }}>School Workload Overview</Title>
-          <Text type="secondary">{filtered.length} staff member(s) shown</Text>
-        </div>
-
-        <Select
-          value={deptFilter}
-          onChange={setDeptFilter}
-          style={{ width: 200 }}
-          options={departments.map((d) => ({ label: d, value: d }))}
-        />
+    <div>
+      <div style={{ marginBottom: 24 }}>
+        <Title level={2} style={{ marginBottom: 4 }}>
+          School Workload
+        </Title>
+        <Text type="secondary">
+          View and search academic workload records across the school.
+        </Text>
       </div>
+
+      {error && (
+        <Alert
+          type="error"
+          message="Request issue"
+          description={error}
+          showIcon
+          style={{ marginBottom: 24 }}
+        />
+      )}
+
+      <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+        <Col xs={24} sm={12} md={6}>
+          <Card>
+            <Statistic title="Academic Staff" value={summary.totalStaff} />
+          </Card>
+        </Col>
+
+        <Col xs={24} sm={12} md={6}>
+          <Card>
+            <Statistic
+              title="Teaching Points"
+              value={Number(summary.totalTeaching.toFixed(2))}
+            />
+          </Card>
+        </Col>
+
+        <Col xs={24} sm={12} md={6}>
+          <Card>
+            <Statistic
+              title="Research Points"
+              value={Number(summary.totalResearch.toFixed(2))}
+            />
+          </Card>
+        </Col>
+
+        <Col xs={24} sm={12} md={6}>
+          <Card>
+            <Statistic
+              title="T:R Discrepancies"
+              value={summary.discrepancyCount}
+            />
+          </Card>
+        </Col>
+      </Row>
 
       <Card>
-        <Table
-          columns={columns}
-          dataSource={filtered}
-          rowKey="staffId"
-          pagination={false}
+        <Space
+          direction="vertical"
           size="middle"
+          style={{ width: "100%", marginBottom: 16 }}
+        >
+          <Space wrap>
+            <Input
+              allowClear
+              prefix={<SearchOutlined />}
+              placeholder="Search academic by name, e.g. Dummy 14 or dummy14"
+              value={searchText}
+              onChange={(event) => setSearchText(event.target.value)}
+              style={{ width: 420 }}
+            />
+
+            <Select
+              value={departmentFilter}
+              onChange={setDepartmentFilter}
+              options={departmentOptions}
+              style={{ width: 220 }}
+            />
+          </Space>
+
+          <Text type="secondary">
+            Showing {filteredWorkloads.length} of {workloads.length} workload
+            records
+          </Text>
+        </Space>
+
+        <Table
+          rowKey="id"
+          columns={columns}
+          dataSource={filteredWorkloads}
+          loading={loading}
+          pagination={{ pageSize: 10 }}
+          scroll={{ x: 1600 }}
         />
       </Card>
-    </Space>
+    </div>
   );
 }

--- a/frontend/src/pages/hod/DeptWorkloadPage.jsx
+++ b/frontend/src/pages/hod/DeptWorkloadPage.jsx
@@ -1,136 +1,345 @@
-import { useState, useEffect } from 'react';
-import { Card, Table, Tag, Typography, Space, Progress, Spin, Alert } from 'antd';
-import { useAuth } from '../../context/AuthContext';
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Card,
+  Col,
+  Input,
+  Row,
+  Space,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import { SearchOutlined } from "@ant-design/icons";
 
 const { Title, Text } = Typography;
 
-export default function DeptWorkloadPage() {
-  const { currentUser } = useAuth();
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
-  const [loading, setLoading] = useState(true);
-  const [workload, setWorkload] = useState([]);
-  const [issues, setIssues] = useState([]);
-  const [error, setError] = useState('');
+function safeParse(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function getCurrentUser() {
+  const possibleKeys = [
+    "wvs_current_user",
+    "user",
+    "currentUser",
+    "authUser",
+    "loggedInUser",
+    "workloadUser",
+  ];
+
+  for (const key of possibleKeys) {
+    const value = localStorage.getItem(key);
+    if (!value) continue;
+
+    const parsed = safeParse(value);
+    if (parsed?.username) return parsed;
+    if (parsed?.user?.username) return parsed.user;
+  }
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    const value = localStorage.getItem(key);
+    const parsed = safeParse(value);
+
+    if (parsed?.username) return parsed;
+    if (parsed?.user?.username) return parsed.user;
+  }
+
+  return null;
+}
+
+function formatNumber(value) {
+  const number = Number(value || 0);
+  return Number.isInteger(number) ? number : number.toFixed(2);
+}
+
+function normalizeSearchText(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+export default function DeptWorkloadPage() {
+  const [workloads, setWorkloads] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [searchText, setSearchText] = useState("");
+
+  const currentUser = getCurrentUser();
+
+  async function loadWorkloads() {
+    try {
+      setLoading(true);
+      setError("");
+
+      if (!currentUser?.username) {
+        throw new Error("No logged-in user found.");
+      }
+
+      const response = await fetch(`${API_URL}/api/workloads`, {
+        headers: {
+          "x-user": currentUser.username,
+        },
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || "Failed to load department workloads.");
+      }
+
+      setWorkloads(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err.message || "Failed to load department workloads.");
+    } finally {
+      setLoading(false);
+    }
+  }
 
   useEffect(() => {
-    const fetchData = async () => {
-      if (!currentUser?.username) {
-        setLoading(false);
-        setError('No logged-in user found.');
-        return;
-      }
+    loadWorkloads();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-      setLoading(true);
-      setError('');
+  const filteredWorkloads = useMemo(() => {
+    const search = searchText.trim().toLowerCase();
+    const normalizedSearch = normalizeSearchText(searchText);
 
-      try {
-        const [workloadRes, issuesRes] = await Promise.all([
-          fetch(`${import.meta.env.VITE_API_URL}/api/workloads`, {
-            headers: {
-              'Content-Type': 'application/json',
-              'x-user': currentUser.username,
-            },
-          }),
-          fetch(`${import.meta.env.VITE_API_URL}/api/validation-issues`, {
-            headers: {
-              'Content-Type': 'application/json',
-              'x-user': currentUser.username,
-            },
-          }),
-        ]);
+    if (!search && !normalizedSearch) return workloads;
 
-        const [workloadData, issuesData] = await Promise.all([
-          workloadRes.json(),
-          issuesRes.json(),
-        ]);
+    return workloads.filter((workload) => {
+      const name = String(workload.name || "").toLowerCase();
+      const normalizedName = normalizeSearchText(workload.name);
 
-        if (!workloadRes.ok) {
-          throw new Error(workloadData.message || 'Failed to load workload.');
-        }
-        if (!issuesRes.ok) {
-          throw new Error(issuesData.message || 'Failed to load validation issues.');
-        }
+      return name.includes(search) || normalizedName.includes(normalizedSearch);
+    });
+  }, [workloads, searchText]);
 
-        setWorkload(Array.isArray(workloadData) ? workloadData : []);
-        setIssues(Array.isArray(issuesData) ? issuesData : []);
-      } catch (error) {
-        console.error('Error fetching data:', error);
-        setError(error.message || 'Unable to load department workload.');
-      } finally {
-        setLoading(false);
-      }
+  const summary = useMemo(() => {
+    const totalStaff = filteredWorkloads.length;
+
+    const totalTeaching = filteredWorkloads.reduce(
+      (sum, item) => sum + Number(item.teaching || 0),
+      0
+    );
+
+    const totalResearch = filteredWorkloads.reduce(
+      (sum, item) => sum + Number(item.research || 0),
+      0
+    );
+
+    const discrepancyCount = filteredWorkloads.filter(
+      (item) => Number(item.hasDiscrepancy) === 1
+    ).length;
+
+    return {
+      totalStaff,
+      totalTeaching,
+      totalResearch,
+      discrepancyCount,
     };
-
-    fetchData();
-  }, [currentUser]);
-
-  const deptWorkload = workload.filter((w) => w.department === currentUser.department);
-  const deptIssues = issues.filter((i) => i.department === currentUser.department);
+  }, [filteredWorkloads]);
 
   const columns = [
-    { title: 'Staff Member', dataIndex: 'name', key: 'name' },
     {
-      title: 'FTE',
-      dataIndex: 'fte',
-      key: 'fte',
-      width: 70,
-      render: (fte) => `${fte}`,
+      title: "Academic Name",
+      dataIndex: "name",
+      key: "name",
+      fixed: "left",
+      width: 230,
+      sorter: (a, b) => String(a.name || "").localeCompare(String(b.name || "")),
     },
     {
-      title: 'Teaching (%)',
-      dataIndex: 'teaching',
-      key: 'teaching',
-      render: (v) => <Progress percent={v} size="small" strokeColor="#003087" />,
+      title: "Department",
+      dataIndex: "department",
+      key: "department",
+      width: 140,
     },
-    { title: 'Research (%)', dataIndex: 'research', key: 'research', render: (v) => `${v}%` },
-    { title: 'HDR (%)', dataIndex: 'hdSupervision', key: 'hdSupervision', render: (v) => `${v}%` },
-    { title: 'Total (%)', dataIndex: 'total', key: 'total', render: (v) => `${v}%` },
     {
-      title: 'Status',
-      dataIndex: 'hasDiscrepancy',
-      key: 'hasDiscrepancy',
-      render: (hasDiscrepancy) =>
-        hasDiscrepancy ? <Tag color="warning">T:R Discrepancy</Tag> : <Tag color="success">Valid</Tag>,
+      title: "FTE",
+      dataIndex: "fte",
+      key: "fte",
+      width: 80,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.fte || 0) - Number(b.fte || 0),
+    },
+    {
+      title: "Teaching",
+      dataIndex: "teaching",
+      key: "teaching",
+      width: 100,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.teaching || 0) - Number(b.teaching || 0),
+    },
+    {
+      title: "Assigned Role",
+      dataIndex: "assignedRole",
+      key: "assignedRole",
+      width: 130,
+      render: formatNumber,
+      sorter: (a, b) =>
+        Number(a.assignedRole || 0) - Number(b.assignedRole || 0),
+    },
+    {
+      title: "Service",
+      dataIndex: "service",
+      key: "service",
+      width: 100,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.service || 0) - Number(b.service || 0),
+    },
+    {
+      title: "HDR",
+      dataIndex: "hdSupervision",
+      key: "hdSupervision",
+      width: 100,
+      render: formatNumber,
+      sorter: (a, b) =>
+        Number(a.hdSupervision || 0) - Number(b.hdSupervision || 0),
+    },
+    {
+      title: "Research",
+      dataIndex: "research",
+      key: "research",
+      width: 100,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.research || 0) - Number(b.research || 0),
+    },
+    {
+      title: "Total",
+      dataIndex: "total",
+      key: "total",
+      width: 90,
+      render: formatNumber,
+      sorter: (a, b) => Number(a.total || 0) - Number(b.total || 0),
+    },
+    {
+      title: "Target Band",
+      dataIndex: "targetBand",
+      key: "targetBand",
+      width: 220,
+      render: (value) => value || "-",
+    },
+    {
+      title: "Calculated Band",
+      dataIndex: "calcBand",
+      key: "calcBand",
+      width: 230,
+      render: (value) => value || "-",
+    },
+    {
+      title: "Discrepancy",
+      dataIndex: "hasDiscrepancy",
+      key: "hasDiscrepancy",
+      width: 120,
+      render: (value) =>
+        Number(value) === 1 ? (
+          <Tag color="red">Yes</Tag>
+        ) : (
+          <Tag color="green">No</Tag>
+        ),
+      filters: [
+        { text: "Has discrepancy", value: 1 },
+        { text: "No discrepancy", value: 0 },
+      ],
+      onFilter: (value, record) => Number(record.hasDiscrepancy) === value,
     },
   ];
 
-  if (loading) {
-    return (
-      <div style={{ textAlign: 'center', marginTop: '100px' }}>
-        <Spin size="large" tip="Loading department workload..." />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <Alert
-        message="Unable to load department workload"
-        description={error}
-        type="error"
-        showIcon
-      />
-    );
-  }
-
   return (
-    <Space direction="vertical" size="large" style={{ width: '100%' }}>
-      <div>
-        <Title level={4} style={{ margin: 0 }}>{currentUser.department} – Workload Overview</Title>
+    <div>
+      <div style={{ marginBottom: 24 }}>
+        <Title level={2} style={{ marginBottom: 4 }}>
+          Department Workload
+        </Title>
         <Text type="secondary">
-          {deptWorkload.length} staff member(s) · {deptIssues.length} issue(s) detected
+          View and search academic workload records for your department.
         </Text>
       </div>
 
+      {error && (
+        <Alert
+          type="error"
+          message="Request issue"
+          description={error}
+          showIcon
+          style={{ marginBottom: 24 }}
+        />
+      )}
+
+      <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+        <Col xs={24} sm={12} md={6}>
+          <Card>
+            <Statistic title="Academic Staff" value={summary.totalStaff} />
+          </Card>
+        </Col>
+
+        <Col xs={24} sm={12} md={6}>
+          <Card>
+            <Statistic
+              title="Teaching Points"
+              value={Number(summary.totalTeaching.toFixed(2))}
+            />
+          </Card>
+        </Col>
+
+        <Col xs={24} sm={12} md={6}>
+          <Card>
+            <Statistic
+              title="Research Points"
+              value={Number(summary.totalResearch.toFixed(2))}
+            />
+          </Card>
+        </Col>
+
+        <Col xs={24} sm={12} md={6}>
+          <Card>
+            <Statistic
+              title="T:R Discrepancies"
+              value={summary.discrepancyCount}
+            />
+          </Card>
+        </Col>
+      </Row>
+
       <Card>
-        <Table
-          columns={columns}
-          dataSource={deptWorkload}
-          rowKey="staffId"
-          pagination={false}
+        <Space
+          direction="vertical"
           size="middle"
+          style={{ width: "100%", marginBottom: 16 }}
+        >
+          <Input
+            allowClear
+            prefix={<SearchOutlined />}
+            placeholder="Search academic by name, e.g. Dummy 14 or dummy14"
+            value={searchText}
+            onChange={(event) => setSearchText(event.target.value)}
+            style={{ maxWidth: 420 }}
+          />
+
+          <Text type="secondary">
+            Showing {filteredWorkloads.length} of {workloads.length} workload
+            records
+          </Text>
+        </Space>
+
+        <Table
+          rowKey="id"
+          columns={columns}
+          dataSource={filteredWorkloads}
+          loading={loading}
+          pagination={{ pageSize: 10 }}
+          scroll={{ x: 1600 }}
         />
       </Card>
-    </Space>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR adds a search bar to the workload pages so users can search for academic staff by name.

This was requested by Bronte so that HoDs, Head of School, and School Operations can quickly find an academic staff member in the workload tables.

## Pages Updated

- HoD Department Workload page
  - CSSE HoD
  - Maths HoD
  - Physics HoD

- Admin School Workload page
  - Head of School
  - School Operations

## Changes Made

- Added an academic name search bar to the HoD department workload page.
- Added an academic name search bar to the Head of School / School Operations workload page.
- Added flexible search matching so users do not need to type the exact Excel formatting.
- Search now ignores spaces, commas, and punctuation.

## Search Examples

For a staff name stored as:

`Dummy, 14`

The following searches will now return the result:

- `dummy`
- `dummy14`
- `dummy 14`
- `Dummy, 14`
- `14`

For a real name such as:

`Neel Rakesh Patel`

The following searches would work:

- `neel`
- `rakesh`
- `patel`
- `neel rakesh`
- `neelrakesh`

## Testing

- Tested search on the HoD department workload page.
- Tested search on the Head of School / School Operations workload page.
- Confirmed search is case-insensitive.
- Confirmed search works without requiring exact punctuation from the Excel file.
- Confirmed clearing the search box restores all workload records.
- Confirmed department filtering on the school workload page still works with the search bar.

closes #30 