### PR TITLE
Add workload year filtering and fresh demo setup

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,6 +1,17 @@
 import sqlite3 from "sqlite3";
 import { open } from "sqlite";
 
+async function ensureColumn(db, tableName, columnName, columnDefinition) {
+  const columns = await db.all(`PRAGMA table_info(${tableName})`);
+  const exists = columns.some((column) => column.name === columnName);
+
+  if (!exists) {
+    await db.run(
+      `ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${columnDefinition}`
+    );
+  }
+}
+
 // Create DB connection
 export async function initDB() {
   const db = await open({
@@ -14,6 +25,8 @@ export async function initDB() {
 
 // Create tables if they do not exist
 export async function setupDB(db) {
+  const currentYear = new Date().getFullYear();
+
   await db.exec(`
     CREATE TABLE IF NOT EXISTS users (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -32,6 +45,7 @@ export async function setupDB(db) {
       filename TEXT NOT NULL,
       uploadedBy TEXT NOT NULL,
       importedAt TEXT NOT NULL,
+      workloadYear INTEGER NOT NULL DEFAULT ${currentYear},
       status TEXT NOT NULL CHECK (status IN ('processing', 'completed', 'failed')),
       staffCount INTEGER NOT NULL DEFAULT 0,
       unitCount INTEGER NOT NULL DEFAULT 0,
@@ -45,8 +59,13 @@ export async function setupDB(db) {
     );
   `);
 
-  // Workload summary table used by dashboards.
-  // importBatchId lets us keep history safely and still show only the latest import.
+  await ensureColumn(
+    db,
+    "import_batches",
+    "workloadYear",
+    `INTEGER NOT NULL DEFAULT ${currentYear}`
+  );
+
   await db.exec(`
     CREATE TABLE IF NOT EXISTS workloads (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -85,8 +104,6 @@ export async function setupDB(db) {
     );
   `);
 
-  // Workbook source tables. These are intentionally more flexible because
-  // they store imported Excel data, including invalid rows that need to be reported.
   await db.exec(`
     CREATE TABLE IF NOT EXISTS staff_sources (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -218,6 +235,14 @@ export async function setupDB(db) {
       FOREIGN KEY (importBatchId) REFERENCES import_batches(id) ON DELETE CASCADE
     );
   `);
+
+  await db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_import_batches_year_status
+    ON import_batches (workloadYear, status);
+
+    CREATE INDEX IF NOT EXISTS idx_workloads_staff_import
+    ON workloads (staffId, importBatchId);
+  `);
 }
 
 // Seed Users
@@ -272,7 +297,8 @@ export async function seedWorkloads(db) {
     const values = [];
 
     for (let i = 1; i <= 18; i++) {
-      const dept = i <= 7 || i === 9 ? "CSSE" : i <= 13 ? "Mathematics" : "Physics";
+      const dept =
+        i <= 7 || i === 9 ? "CSSE" : i <= 13 ? "Mathematics" : "Physics";
 
       values.push(
         `(NULL, ${i}, 'Dummy, ${String(i).padStart(

--- a/backend/server.js
+++ b/backend/server.js
@@ -76,8 +76,7 @@ async function startServer() {
   db = await initDB();
   await setupDB(db);
   await seedUsers(db);
-  await seedWorkloads(db);
-  await seedQueries(db);
+//await seedWorkloads(db);
 
   app.listen(PORT, () => {
     console.log(`Server running at http://localhost:${PORT}`);
@@ -142,39 +141,108 @@ function normalizeQueryStatus(value) {
   return null;
 }
 
-async function getLatestImportBatch() {
+function parseWorkloadYear(value) {
+  const currentYear = new Date().getFullYear();
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed)) {
+    return currentYear;
+  }
+
+  if (parsed < 2000 || parsed > currentYear + 1) {
+    return currentYear;
+  }
+
+  return parsed;
+}
+
+function parseOptionalWorkloadYear(value) {
+  const currentYear = new Date().getFullYear();
+
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  if (parsed < 2000 || parsed > currentYear + 1) {
+    return null;
+  }
+
+  return parsed;
+}
+
+// -----------------------------
+// IMPORT / WORKLOAD HELPERS
+// -----------------------------
+
+async function getImportBatch(workloadYear = null) {
+  if (workloadYear) {
+    return db.get(
+      `SELECT *
+       FROM import_batches
+       WHERE status = 'completed'
+         AND workloadYear = ?
+       ORDER BY importedAt DESC, id DESC
+       LIMIT 1`,
+      [workloadYear]
+    );
+  }
+
   return db.get(
-    "SELECT * FROM import_batches WHERE status = 'completed' ORDER BY id DESC LIMIT 1"
+    `SELECT *
+     FROM import_batches
+     WHERE status = 'completed'
+     ORDER BY workloadYear DESC, importedAt DESC, id DESC
+     LIMIT 1`
   );
 }
 
-async function getVisibleWorkloads(user) {
-  const latestImport = await getLatestImportBatch();
+async function getLatestImportBatch() {
+  return getImportBatch();
+}
+
+async function getVisibleWorkloads(user, workloadYear = null) {
+  const selectedImport = await getImportBatch(workloadYear);
 
   const whereParts = [];
   const params = [];
 
-  if (latestImport) {
-    whereParts.push("importBatchId = ?");
-    params.push(latestImport.id);
+  if (selectedImport) {
+    whereParts.push("w.importBatchId = ?");
+    params.push(selectedImport.id);
+  } else if (workloadYear) {
+    return [];
   } else {
-    whereParts.push("importBatchId IS NULL");
+    whereParts.push("w.importBatchId IS NULL");
   }
 
   if (user.role === "staff") {
-    whereParts.push("staffId = ?");
+    whereParts.push("w.staffId = ?");
     params.push(user.staffId);
   }
 
   if (user.role === "hod") {
-    whereParts.push("department = ?");
+    whereParts.push("w.department = ?");
     params.push(user.department);
   }
 
   const whereSql = `WHERE ${whereParts.join(" AND ")}`;
 
   return db.all(
-    `SELECT * FROM workloads ${whereSql} ORDER BY department ASC, name ASC`,
+    `SELECT
+       w.*,
+       b.workloadYear,
+       b.filename,
+       b.importedAt
+     FROM workloads w
+     LEFT JOIN import_batches b ON b.id = w.importBatchId
+     ${whereSql}
+     ORDER BY w.department ASC, w.name ASC`,
     params
   );
 }
@@ -238,7 +306,8 @@ app.get(
   authorizeRoles("staff"),
   async (req, res) => {
     try {
-      const workloads = await getVisibleWorkloads(req.user);
+      const workloadYear = parseOptionalWorkloadYear(req.query.workloadYear);
+      const workloads = await getVisibleWorkloads(req.user, workloadYear);
       const workload = workloads[0];
 
       if (!workload) {
@@ -254,12 +323,95 @@ app.get(
 );
 
 app.get(
+  "/api/workloads/my/history",
+  mockAuth,
+  authorizeRoles("staff"),
+  async (req, res) => {
+    try {
+      const requestedYears = Number.parseInt(req.query.years, 10);
+      const numberOfYears =
+        Number.isFinite(requestedYears) && requestedYears > 0
+          ? requestedYears
+          : 2;
+
+      const currentWorkloadYearRow = await db.get(
+        `SELECT b.workloadYear
+         FROM import_batches b
+         JOIN workloads w ON w.importBatchId = b.id
+         WHERE b.status = 'completed'
+           AND w.staffId = ?
+           AND b.workloadYear IS NOT NULL
+         ORDER BY b.workloadYear DESC, b.importedAt DESC, b.id DESC
+         LIMIT 1`,
+        [req.user.staffId]
+      );
+
+      if (!currentWorkloadYearRow) {
+        return res.json([]);
+      }
+
+      const currentWorkloadYear = currentWorkloadYearRow.workloadYear;
+
+      const pastYears = await db.all(
+        `SELECT DISTINCT b.workloadYear
+         FROM import_batches b
+         JOIN workloads w ON w.importBatchId = b.id
+         WHERE b.status = 'completed'
+           AND w.staffId = ?
+           AND b.workloadYear IS NOT NULL
+           AND b.workloadYear < ?
+         ORDER BY b.workloadYear DESC
+         LIMIT ?`,
+        [req.user.staffId, currentWorkloadYear, numberOfYears]
+      );
+
+      const years = pastYears.map((row) => row.workloadYear);
+
+      if (years.length === 0) {
+        return res.json([]);
+      }
+
+      const placeholders = years.map(() => "?").join(",");
+
+      const history = await db.all(
+        `SELECT
+           w.*,
+           b.workloadYear,
+           b.filename,
+           b.importedAt
+         FROM workloads w
+         JOIN import_batches b ON b.id = w.importBatchId
+         WHERE w.staffId = ?
+           AND b.status = 'completed'
+           AND b.workloadYear IN (${placeholders})
+           AND b.id IN (
+             SELECT MAX(id)
+             FROM import_batches
+             WHERE status = 'completed'
+               AND workloadYear IN (${placeholders})
+             GROUP BY workloadYear
+           )
+         ORDER BY b.workloadYear DESC, b.importedAt DESC, b.id DESC`,
+        [req.user.staffId, ...years, ...years]
+      );
+
+      res.json(history);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  }
+);
+
+app.get(
   "/api/workloads",
   mockAuth,
   authorizeRoles("hod", "hos", "operations"),
   async (req, res) => {
     try {
-      const workloads = await getVisibleWorkloads(req.user);
+      const workloadYear = parseOptionalWorkloadYear(req.query.workloadYear);
+      const workloads = await getVisibleWorkloads(req.user, workloadYear);
+
       res.json(workloads);
     } catch (err) {
       console.error(err);
@@ -283,11 +435,14 @@ app.post(
         return res.status(400).json({ message: "No file uploaded" });
       }
 
+      const workloadYear = parseWorkloadYear(req.body.workloadYear);
+
       const result = await importExcelWorkbook({
         db,
         filePath: req.file.path,
         originalName: req.file.originalname,
         uploadedBy: req.user,
+        workloadYear,
       });
 
       if (req.file?.path && fs.existsSync(req.file.path)) {
@@ -318,7 +473,10 @@ app.get(
   authorizeRoles("hod", "hos", "operations"),
   async (req, res) => {
     try {
-      const report = await getLatestImportReport(db, req.user);
+      const workloadYear = parseOptionalWorkloadYear(req.query.workloadYear);
+
+      const report = await getLatestImportReport(db, req.user, workloadYear);
+
       res.json(report);
     } catch (err) {
       console.error(err);
@@ -333,8 +491,24 @@ app.get(
   authorizeRoles("hos", "operations"),
   async (req, res) => {
     try {
+      const workloadYear = parseOptionalWorkloadYear(req.query.workloadYear);
+
+      if (workloadYear) {
+        const batches = await db.all(
+          `SELECT *
+           FROM import_batches
+           WHERE workloadYear = ?
+           ORDER BY importedAt DESC, id DESC`,
+          [workloadYear]
+        );
+
+        return res.json(batches);
+      }
+
       const batches = await db.all(
-        "SELECT * FROM import_batches ORDER BY importedAt DESC"
+        `SELECT *
+         FROM import_batches
+         ORDER BY workloadYear DESC, importedAt DESC, id DESC`
       );
 
       res.json(batches);
@@ -409,36 +583,41 @@ function generateValidationIssues(workloads) {
   return issues;
 }
 
-async function getLatestStoredIssues(user) {
-  const latestImport = await getLatestImportBatch();
+async function getLatestStoredIssues(user, workloadYear = null) {
+  const selectedImport = await getImportBatch(workloadYear);
 
-  if (!latestImport) {
+  if (!selectedImport) {
     return null;
   }
 
   if (user.role === "staff") {
     return db.all(
-      `SELECT * FROM validation_issues
-       WHERE importBatchId = ? AND staffId = ?
+      `SELECT *
+       FROM validation_issues
+       WHERE importBatchId = ?
+         AND staffId = ?
        ORDER BY severity ASC, type ASC`,
-      [latestImport.id, user.staffId]
+      [selectedImport.id, user.staffId]
     );
   }
 
   if (user.role === "hod") {
     return db.all(
-      `SELECT * FROM validation_issues
-       WHERE importBatchId = ? AND department = ?
+      `SELECT *
+       FROM validation_issues
+       WHERE importBatchId = ?
+         AND department = ?
        ORDER BY severity ASC, type ASC, staffName ASC`,
-      [latestImport.id, user.department]
+      [selectedImport.id, user.department]
     );
   }
 
   return db.all(
-    `SELECT * FROM validation_issues
+    `SELECT *
+     FROM validation_issues
      WHERE importBatchId = ?
      ORDER BY severity ASC, type ASC, staffName ASC`,
-    [latestImport.id]
+    [selectedImport.id]
   );
 }
 
@@ -448,13 +627,33 @@ app.get(
   authorizeRoles("staff"),
   async (req, res) => {
     try {
-      const storedIssues = await getLatestStoredIssues(req.user);
+      const requestedImportBatchId = Number.parseInt(
+        req.query.importBatchId,
+        10
+      );
+
+      if (Number.isFinite(requestedImportBatchId)) {
+        const issues = await db.all(
+          `SELECT *
+           FROM validation_issues
+           WHERE importBatchId = ?
+             AND staffId = ?
+           ORDER BY severity ASC, type ASC`,
+          [requestedImportBatchId, req.user.staffId]
+        );
+
+        return res.json(issues);
+      }
+
+      const workloadYear = parseOptionalWorkloadYear(req.query.workloadYear);
+
+      const storedIssues = await getLatestStoredIssues(req.user, workloadYear);
 
       if (storedIssues) {
         return res.json(storedIssues);
       }
 
-      const workloads = await getVisibleWorkloads(req.user);
+      const workloads = await getVisibleWorkloads(req.user, workloadYear);
       res.json(generateValidationIssues(workloads));
     } catch (err) {
       console.error(err);
@@ -469,13 +668,15 @@ app.get(
   authorizeRoles("hod", "hos", "operations"),
   async (req, res) => {
     try {
-      const storedIssues = await getLatestStoredIssues(req.user);
+      const workloadYear = parseOptionalWorkloadYear(req.query.workloadYear);
+
+      const storedIssues = await getLatestStoredIssues(req.user, workloadYear);
 
       if (storedIssues) {
         return res.json(storedIssues);
       }
 
-      const workloads = await getVisibleWorkloads(req.user);
+      const workloads = await getVisibleWorkloads(req.user, workloadYear);
       res.json(generateValidationIssues(workloads));
     } catch (err) {
       console.error(err);

--- a/backend/services/excelImportService.js
+++ b/backend/services/excelImportService.js
@@ -288,7 +288,13 @@ async function insertIssue(db, importBatchId, issue) {
   );
 }
 
-export async function importExcelWorkbook({ db, filePath, originalName, uploadedBy }) {
+export async function importExcelWorkbook({
+  db,
+  filePath,
+  originalName,
+  uploadedBy,
+  workloadYear = new Date().getFullYear(),
+}) {
   const workbook = xlsx.readFile(filePath, {
     cellDates: true,
     cellFormula: false,
@@ -836,17 +842,19 @@ export async function importExcelWorkbook({ db, filePath, originalName, uploaded
   await db.exec("BEGIN TRANSACTION");
 
   try {
-    const batchResult = await db.run(
-      `INSERT INTO import_batches (filename, uploadedBy, importedAt, status, notes)
-       VALUES (?, ?, ?, ?, ?)`,
-      [
-        originalName,
-        uploadedBy?.username || uploadedBy?.name || "unknown",
-        new Date().toISOString(),
-        "processing",
-        "Import started. Data is stored under this import batch.",
-      ]
-    );
+  const batchResult = await db.run(
+  `INSERT INTO import_batches
+   (filename, uploadedBy, importedAt, workloadYear, status, notes)
+   VALUES (?, ?, ?, ?, ?, ?)`,
+  [
+    originalName,
+    uploadedBy?.username || uploadedBy?.name || "unknown",
+    new Date().toISOString(),
+    workloadYear,
+    "processing",
+    `Import started for workload year ${workloadYear}. Data is stored under this import batch.`,
+  ]
+);
 
     importBatchId = batchResult.lastID;
 
@@ -1048,6 +1056,7 @@ export async function importExcelWorkbook({ db, filePath, originalName, uploaded
 
   return {
     importBatchId,
+    workloadYear,
     imported: {
       staff: parsedStaff.length,
       units: parsedUnits.length,
@@ -1061,10 +1070,26 @@ export async function importExcelWorkbook({ db, filePath, originalName, uploaded
   };
 }
 
-export async function getLatestImportReport(db, user) {
-  const latestImport = await db.get(
-    "SELECT * FROM import_batches WHERE status = 'completed' ORDER BY id DESC LIMIT 1"
-  );
+export async function getLatestImportReport(db, user, workloadYear = null) {
+  let latestImport;
+
+  if (workloadYear) {
+    latestImport = await db.get(
+      `SELECT * FROM import_batches
+       WHERE status = 'completed'
+         AND workloadYear = ?
+       ORDER BY importedAt DESC, id DESC
+       LIMIT 1`,
+      [workloadYear]
+    );
+  } else {
+    latestImport = await db.get(
+      `SELECT * FROM import_batches
+       WHERE status = 'completed'
+       ORDER BY workloadYear DESC, importedAt DESC, id DESC
+       LIMIT 1`
+    );
+  }
 
   if (!latestImport) {
     return {
@@ -1095,7 +1120,15 @@ export async function getLatestImportReport(db, user) {
   );
 
   const workloads = await db.all(
-    `SELECT * FROM workloads ${workloadWhere} ORDER BY department ASC, name ASC`,
+    `SELECT
+       w.*,
+       b.workloadYear,
+       b.filename,
+       b.importedAt
+     FROM workloads w
+     LEFT JOIN import_batches b ON b.id = w.importBatchId
+     ${workloadWhere}
+     ORDER BY w.department ASC, w.name ASC`,
     workloadParams
   );
 

--- a/frontend/src/api/importApi.js
+++ b/frontend/src/api/importApi.js
@@ -12,11 +12,8 @@ function extractUsernameFromUserObject(user) {
   if (!user || typeof user !== "object") return null;
 
   if (user.username) return user.username;
-
   if (user.user?.username) return user.user.username;
-
   if (user.currentUser?.username) return user.currentUser.username;
-
   if (user.authUser?.username) return user.authUser.username;
 
   const role = user.role || user.user?.role || user.currentUser?.role;
@@ -47,6 +44,7 @@ function extractUsernameFromUserObject(user) {
 
 function getCurrentUsername() {
   const possibleKeys = [
+    "wvs_current_user",
     "user",
     "currentUser",
     "authUser",
@@ -77,7 +75,7 @@ function getCurrentUsername() {
   return null;
 }
 
-export async function uploadExcelFile(file) {
+function getAuthHeaders() {
   const username = getCurrentUsername();
 
   if (!username) {
@@ -86,14 +84,25 @@ export async function uploadExcelFile(file) {
     );
   }
 
+  return {
+    "x-user": username,
+  };
+}
+
+function buildYearQuery(workloadYear) {
+  if (!workloadYear) return "";
+
+  return `?workloadYear=${encodeURIComponent(workloadYear)}`;
+}
+
+export async function uploadExcelFile(file, workloadYear) {
   const formData = new FormData();
   formData.append("file", file);
+  formData.append("workloadYear", String(workloadYear));
 
   const response = await fetch(`${API_URL}/api/import/excel`, {
     method: "POST",
-    headers: {
-      "x-user": username,
-    },
+    headers: getAuthHeaders(),
     body: formData,
   });
 
@@ -106,26 +115,35 @@ export async function uploadExcelFile(file) {
   return data;
 }
 
-export async function getImportReport() {
-  const username = getCurrentUsername();
+export async function getImportReport(workloadYear = null) {
+  const query = buildYearQuery(workloadYear);
 
-  if (!username) {
-    throw new Error(
-      "No logged-in user found. Please log out and log in again as School Operations."
-    );
-  }
-
-  const response = await fetch(`${API_URL}/api/import/report`, {
+  const response = await fetch(`${API_URL}/api/import/report${query}`, {
     method: "GET",
-    headers: {
-      "x-user": username,
-    },
+    headers: getAuthHeaders(),
   });
 
   const data = await response.json();
 
   if (!response.ok) {
     throw new Error(data.message || "Failed to load import report.");
+  }
+
+  return data;
+}
+
+export async function getImportBatches(workloadYear = null) {
+  const query = buildYearQuery(workloadYear);
+
+  const response = await fetch(`${API_URL}/api/import/batches${query}`, {
+    method: "GET",
+    headers: getAuthHeaders(),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data.message || "Failed to load import batches.");
   }
 
   return data;

--- a/frontend/src/pages/admin/ImportData.jsx
+++ b/frontend/src/pages/admin/ImportData.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
   Button,
@@ -6,6 +6,7 @@ import {
   Col,
   Divider,
   Row,
+  Select,
   Space,
   Spin,
   Statistic,
@@ -32,30 +33,93 @@ function severityColor(severity) {
   return "blue";
 }
 
+function detectYearFromFilename(fileName) {
+  const match = String(fileName || "").match(/\b(20\d{2})\b/);
+
+  if (!match) return null;
+
+  const year = Number.parseInt(match[1], 10);
+  const currentYear = new Date().getFullYear();
+
+  if (year < 2000 || year > currentYear + 1) {
+    return null;
+  }
+
+  return year;
+}
+
 export default function ImportData() {
+  const currentYear = new Date().getFullYear();
+
+  const yearOptions = useMemo(
+    () =>
+      [
+        currentYear,
+        currentYear - 1,
+        currentYear - 2,
+        currentYear - 3,
+        currentYear - 4,
+      ].map((year) => ({
+        label: `${year} workload`,
+        value: year,
+      })),
+    [currentYear]
+  );
+
   const [selectedFile, setSelectedFile] = useState(null);
+  const [selectedYear, setSelectedYear] = useState(currentYear);
   const [uploading, setUploading] = useState(false);
-  const [loadingReport, setLoadingReport] = useState(false);
+  const [loadingReport, setLoadingReport] = useState(true);
   const [report, setReport] = useState(null);
   const [error, setError] = useState("");
 
-  async function loadReport() {
+  const loadReport = useCallback(async (yearToLoad = selectedYear) => {
     try {
       setLoadingReport(true);
       setError("");
 
-      const data = await getImportReport();
+      const data = await getImportReport(yearToLoad);
+
       setReport(data);
     } catch (err) {
+      setReport(null);
       setError(err.message || "Could not load import report.");
     } finally {
       setLoadingReport(false);
     }
-  }
+  }, [selectedYear]);
 
   useEffect(() => {
-    loadReport();
-  }, []);
+    let cancelled = false;
+
+    async function loadReportForSelectedYear() {
+      try {
+        setLoadingReport(true);
+        setError("");
+
+        const data = await getImportReport(selectedYear);
+
+        if (!cancelled) {
+          setReport(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setReport(null);
+          setError(err.message || "Could not load import report.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingReport(false);
+        }
+      }
+    }
+
+    loadReportForSelectedYear();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedYear]);
 
   async function handleUpload() {
     if (!selectedFile) {
@@ -63,16 +127,21 @@ export default function ImportData() {
       return;
     }
 
+    if (!selectedYear) {
+      message.warning("Please select a workload year.");
+      return;
+    }
+
     try {
       setUploading(true);
       setError("");
 
-      await uploadExcelFile(selectedFile);
+      await uploadExcelFile(selectedFile, selectedYear);
 
-      message.success("Excel import completed successfully.");
+      message.success(`Excel import completed for ${selectedYear}.`);
       setSelectedFile(null);
 
-      await loadReport();
+      await loadReport(selectedYear);
     } catch (err) {
       setError(err.message || "Excel import failed.");
       message.error(err.message || "Excel import failed.");
@@ -87,6 +156,14 @@ export default function ImportData() {
     accept: ".xlsm,.xlsx,.xls",
     beforeUpload: (file) => {
       setSelectedFile(file);
+
+      const detectedYear = detectYearFromFilename(file.name);
+
+      if (detectedYear) {
+        setSelectedYear(detectedYear);
+        message.info(`Detected workload year ${detectedYear} from file name.`);
+      }
+
       return false;
     },
     onRemove: () => {
@@ -144,13 +221,22 @@ export default function ImportData() {
       dataIndex: "sourceSheet",
       key: "sourceSheet",
       width: 220,
+      render: (value) => value || "-",
     },
     {
       title: "Row",
       dataIndex: "sourceRow",
       key: "sourceRow",
-      width: 90,
-      render: (value) => value || "-",
+      width: 110,
+      render: (value, record) => {
+        if (value) return value;
+
+        if (record.sourceSheet === "Calculated Workload Summary") {
+          return "System";
+        }
+
+        return "-";
+      },
     },
   ];
 
@@ -259,7 +345,7 @@ export default function ImportData() {
         </Title>
         <Text type="secondary">
           Upload Excel workload source files, parse them into the database, and
-          review validation issues.
+          review validation issues by workload year.
         </Text>
       </div>
 
@@ -273,37 +359,58 @@ export default function ImportData() {
         />
       )}
 
-      <Card title="Upload Workload Excel File" style={{ marginBottom: 24 }}>
-        <Dragger {...uploadProps} style={{ marginBottom: 16 }}>
-          <p className="ant-upload-drag-icon">
-            <InboxOutlined />
-          </p>
-          <p className="ant-upload-text">
-            Click or drag the Excel file here to upload
-          </p>
-          <p className="ant-upload-hint">
-            Accepted file types: .xlsm, .xlsx, .xls
-          </p>
-        </Dragger>
+      <Card title="Upload and View Workload Data" style={{ marginBottom: 24 }}>
+        <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+          <div>
+            <Text strong>Workload year</Text>
+            <br />
+            <Text type="secondary">
+              Select the year this spreadsheet belongs to. The import summary,
+              validation issues, and workload records below will also update to
+              this selected year.
+            </Text>
 
-        <Space>
-          <Button
-            type="primary"
-            icon={<UploadOutlined />}
-            loading={uploading}
-            disabled={!selectedFile}
-            onClick={handleUpload}
-          >
-            Import Excel File
-          </Button>
+            <Select
+              value={selectedYear}
+              options={yearOptions}
+              onChange={(year) => {
+                setSelectedYear(year);
+              }}
+              style={{ width: 220, display: "block", marginTop: 8 }}
+            />
+          </div>
 
-          <Button
-            icon={<ReloadOutlined />}
-            loading={loadingReport}
-            onClick={loadReport}
-          >
-            Refresh Report
-          </Button>
+          <Dragger {...uploadProps}>
+            <p className="ant-upload-drag-icon">
+              <InboxOutlined />
+            </p>
+            <p className="ant-upload-text">
+              Click or drag the Excel file here to upload
+            </p>
+            <p className="ant-upload-hint">
+              Accepted file types: .xlsm, .xlsx, .xls
+            </p>
+          </Dragger>
+
+          <Space>
+            <Button
+              type="primary"
+              icon={<UploadOutlined />}
+              loading={uploading}
+              disabled={!selectedFile}
+              onClick={handleUpload}
+            >
+              Import Excel File
+            </Button>
+
+            <Button
+              icon={<ReloadOutlined />}
+              loading={loadingReport}
+              onClick={() => loadReport(selectedYear)}
+            >
+              Refresh Report
+            </Button>
+          </Space>
         </Space>
       </Card>
 
@@ -311,39 +418,71 @@ export default function ImportData() {
         {!latestImport ? (
           <Alert
             type="info"
-            message="No import report yet"
-            description="Upload an Excel workbook to generate the first import report."
+            message={`No import report found for ${selectedYear}`}
+            description="Upload an Excel workbook for this workload year to generate an import report."
             showIcon
           />
         ) : (
           <>
-            <Card title="Latest Import Summary" style={{ marginBottom: 24 }}>
+            <Card
+              title={`Import Summary for ${selectedYear}`}
+              style={{ marginBottom: 24 }}
+            >
               <Row gutter={[16, 16]}>
                 <Col xs={24} sm={12} md={6}>
                   <Statistic
-                    title="Staff Imported"
-                    value={latestImport.staffCount}
+                    title="Workload Year"
+                    value={latestImport.workloadYear || selectedYear}
+                    formatter={(value) => value}
                   />
                 </Col>
 
                 <Col xs={24} sm={12} md={6}>
                   <Statistic
-                    title="Units Imported"
-                    value={latestImport.unitCount}
-                  />
-                </Col>
-
-                <Col xs={24} sm={12} md={6}>
-                  <Statistic
-                    title="Workloads Created"
-                    value={latestImport.workloadCount}
+                    title="Staff Workloads Created"
+                    value={latestImport.workloadCount || 0}
                   />
                 </Col>
 
                 <Col xs={24} sm={12} md={6}>
                   <Statistic
                     title="Validation Issues"
-                    value={latestImport.issueCount}
+                    value={latestImport.issueCount || 0}
+                  />
+                </Col>
+
+                <Col xs={24} sm={12} md={6}>
+                  <Statistic
+                    title="Staff Imported"
+                    value={latestImport.staffCount || 0}
+                  />
+                </Col>
+
+                <Col xs={24} sm={12} md={6}>
+                  <Statistic
+                    title="Units Imported"
+                    value={latestImport.unitCount || 0}
+                  />
+                </Col>
+
+                <Col xs={24} sm={12} md={6}>
+                  <Statistic
+                    title="Teaching Rows"
+                    value={latestImport.teachingRowCount || 0}
+                  />
+                </Col>
+
+                <Col xs={24} sm={12} md={6}>
+                  <Statistic
+                    title="HDR Rows"
+                    value={latestImport.hdrRowCount || 0}
+                  />
+                </Col>
+
+                <Col xs={24} sm={12} md={6}>
+                  <Statistic
+                    title="Assigned Role Rows"
+                    value={latestImport.assignedRoleRowCount || 0}
                   />
                 </Col>
               </Row>
@@ -352,25 +491,27 @@ export default function ImportData() {
 
               <Space direction="vertical" size={4}>
                 <Text>
-                  <strong>File:</strong> {latestImport.filename}
+                  <strong>File:</strong> {latestImport.filename || "-"}
                 </Text>
 
                 <Text>
-                  <strong>Uploaded by:</strong> {latestImport.uploadedBy}
+                  <strong>Uploaded by:</strong> {latestImport.uploadedBy || "-"}
                 </Text>
 
                 <Text>
                   <strong>Imported at:</strong>{" "}
-                  {new Date(latestImport.importedAt).toLocaleString()}
+                  {latestImport.importedAt
+                    ? new Date(latestImport.importedAt).toLocaleString()
+                    : "-"}
                 </Text>
 
                 <Text>
                   <strong>Status:</strong>{" "}
-                  <Tag color="green">{latestImport.status}</Tag>
+                  <Tag color="green">{latestImport.status || "completed"}</Tag>
                 </Text>
 
                 <Text>
-                  <strong>Notes:</strong> {latestImport.notes}
+                  <strong>Notes:</strong> {latestImport.notes || "-"}
                 </Text>
               </Space>
             </Card>
@@ -383,7 +524,10 @@ export default function ImportData() {
                   label: `Validation Issues (${validationIssues.length})`,
                   children: (
                     <Table
-                      rowKey="id"
+                      rowKey={(record) =>
+                        record.id ||
+                        `${record.type}-${record.staffId}-${record.sourceRow}`
+                      }
                       columns={issueColumns}
                       dataSource={validationIssues}
                       pagination={{ pageSize: 10 }}
@@ -408,7 +552,7 @@ export default function ImportData() {
                   label: `Workloads (${workloads.length})`,
                   children: (
                     <Table
-                      rowKey="id"
+                      rowKey={(record) => record.id || record.staffId}
                       columns={workloadColumns}
                       dataSource={workloads}
                       pagination={{ pageSize: 10 }}

--- a/frontend/src/pages/admin/SchoolWorkloadPage.jsx
+++ b/frontend/src/pages/admin/SchoolWorkloadPage.jsx
@@ -1,18 +1,40 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Card, Table, Tag, Typography, Space, Select, Spin, Alert } from 'antd';
 import { useAuth } from '../../context/AuthContext';
 
 const { Title, Text } = Typography;
 
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 const ANNUAL_HOURS_PER_FTE = 1600;
 
 function calculateHours(percent, fte = 1) {
-  return Math.round(((Number(percent) || 0) / 100) * ANNUAL_HOURS_PER_FTE * (Number(fte) || 1));
+  return Math.round(
+    ((Number(percent) || 0) / 100) *
+      ANNUAL_HOURS_PER_FTE *
+      (Number(fte) || 1)
+  );
 }
 
 export default function SchoolWorkloadPage() {
   const { currentUser } = useAuth();
+  const currentYear = new Date().getFullYear();
 
+  const yearOptions = useMemo(
+    () =>
+      [
+        currentYear,
+        currentYear - 1,
+        currentYear - 2,
+        currentYear - 3,
+        currentYear - 4,
+      ].map((year) => ({
+        label: `${year} workload`,
+        value: year,
+      })),
+    [currentYear]
+  );
+
+  const [selectedYear, setSelectedYear] = useState(currentYear);
   const [loading, setLoading] = useState(true);
   const [workload, setWorkload] = useState([]);
   const [deptFilter, setDeptFilter] = useState('All');
@@ -30,12 +52,15 @@ export default function SchoolWorkloadPage() {
       setError('');
 
       try {
-        const response = await fetch(`${import.meta.env.VITE_API_URL}/api/workloads`, {
-          headers: {
-            'Content-Type': 'application/json',
-            'x-user': currentUser.username,
-          },
-        });
+        const response = await fetch(
+          `${API_URL}/api/workloads?workloadYear=${selectedYear}`,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user': currentUser.username,
+            },
+          }
+        );
 
         const data = await response.json();
 
@@ -44,6 +69,7 @@ export default function SchoolWorkloadPage() {
         }
 
         setWorkload(Array.isArray(data) ? data : []);
+        setDeptFilter('All');
       } catch (err) {
         console.error('Failed to load workload:', err);
         setError(err.message || 'Unable to load workload data.');
@@ -53,7 +79,7 @@ export default function SchoolWorkloadPage() {
     };
 
     fetchData();
-  }, [currentUser]);
+  }, [currentUser, selectedYear]);
 
   const enhancedWorkload = workload.map((w) => ({
     ...w,
@@ -65,7 +91,10 @@ export default function SchoolWorkloadPage() {
     totalHours: calculateHours(w.total, w.fte),
   }));
 
-  const departments = ['All', ...new Set(enhancedWorkload.map((w) => w.department).filter(Boolean))];
+  const departments = [
+    'All',
+    ...new Set(enhancedWorkload.map((w) => w.department).filter(Boolean)),
+  ];
 
   const filtered =
     deptFilter === 'All'
@@ -73,9 +102,25 @@ export default function SchoolWorkloadPage() {
       : enhancedWorkload.filter((w) => w.department === deptFilter);
 
   const columns = [
-    { title: 'Staff Member', dataIndex: 'name', key: 'name', fixed: 'left', width: 150 },
-    { title: 'Department', dataIndex: 'department', key: 'department', width: 130 },
-    { title: 'FTE', dataIndex: 'fte', key: 'fte', width: 70 },
+    {
+      title: 'Staff Member',
+      dataIndex: 'name',
+      key: 'name',
+      fixed: 'left',
+      width: 150,
+    },
+    {
+      title: 'Department',
+      dataIndex: 'department',
+      key: 'department',
+      width: 130,
+    },
+    {
+      title: 'FTE',
+      dataIndex: 'fte',
+      key: 'fte',
+      width: 70,
+    },
     {
       title: 'Teaching',
       key: 'teaching',
@@ -177,27 +222,64 @@ export default function SchoolWorkloadPage() {
 
   return (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 16,
+          alignItems: 'flex-end',
+          flexWrap: 'wrap',
+        }}
+      >
         <div>
-          <Title level={4} style={{ margin: 0 }}>School Workload Overview</Title>
+          <Title level={4} style={{ margin: 0 }}>
+            School Workload Overview
+          </Title>
           <Text type="secondary">
-            {filtered.length} staff member(s) shown · Estimated on {ANNUAL_HOURS_PER_FTE} hours per 1.0 FTE
+            {selectedYear} workload · {filtered.length} staff member(s) shown ·
+            Estimated on {ANNUAL_HOURS_PER_FTE} hours per 1.0 FTE
           </Text>
         </div>
 
-        <Select
-          value={deptFilter}
-          onChange={setDeptFilter}
-          style={{ width: 200 }}
-          options={departments.map((d) => ({ label: d, value: d }))}
-        />
+        <Space>
+          <div>
+            <Text type="secondary">Workload year</Text>
+            <br />
+            <Select
+              value={selectedYear}
+              onChange={setSelectedYear}
+              style={{ width: 180 }}
+              options={yearOptions}
+            />
+          </div>
+
+          <div>
+            <Text type="secondary">Department</Text>
+            <br />
+            <Select
+              value={deptFilter}
+              onChange={setDeptFilter}
+              style={{ width: 200 }}
+              options={departments.map((d) => ({ label: d, value: d }))}
+            />
+          </div>
+        </Space>
       </div>
+
+      {filtered.length === 0 && (
+        <Alert
+          type="info"
+          showIcon
+          message={`No workload data found for ${selectedYear}.`}
+          description="Upload a workload spreadsheet for this year from the Import Data page."
+        />
+      )}
 
       <Card>
         <Table
           columns={columns}
           dataSource={filtered}
-          rowKey="staffId"
+          rowKey={(record) => `${record.importBatchId || 'demo'}-${record.staffId}`}
           pagination={false}
           size="middle"
           scroll={{ x: 1200 }}

--- a/frontend/src/pages/staff/WorkloadPage.jsx
+++ b/frontend/src/pages/staff/WorkloadPage.jsx
@@ -1,4 +1,15 @@
-import { Card, Table, Typography, Alert, Button, Descriptions, Space, Spin } from 'antd';
+import {
+  Card,
+  Table,
+  Typography,
+  Alert,
+  Button,
+  Descriptions,
+  Space,
+  Spin,
+  Tag,
+  Select,
+} from 'antd';
 import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import { useState, useEffect } from 'react';
@@ -6,10 +17,24 @@ import { useAuth } from '../../context/AuthContext';
 
 const { Title, Text } = Typography;
 
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 const ANNUAL_HOURS_PER_FTE = 1600;
 
 function calculateHours(percent, fte = 1) {
-  return Math.round(((Number(percent) || 0) / 100) * ANNUAL_HOURS_PER_FTE * (Number(fte) || 1));
+  return Math.round(
+    ((Number(percent) || 0) / 100) *
+      ANNUAL_HOURS_PER_FTE *
+      (Number(fte) || 1)
+  );
+}
+
+function formatPercent(value) {
+  return `${Number(value || 0)}%`;
+}
+
+function formatDate(value) {
+  if (!value) return '-';
+  return new Date(value).toLocaleDateString();
 }
 
 export default function StaffWorkloadPage() {
@@ -17,6 +42,8 @@ export default function StaffWorkloadPage() {
   const navigate = useNavigate();
 
   const [workload, setWorkload] = useState(null);
+  const [history, setHistory] = useState([]);
+  const [selectedWorkloadKey, setSelectedWorkloadKey] = useState('current');
   const [issues, setIssues] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -33,14 +60,14 @@ export default function StaffWorkloadPage() {
       setError('');
 
       try {
-        const [workloadRes, issuesRes] = await Promise.all([
-          fetch(`${import.meta.env.VITE_API_URL}/api/workloads/my`, {
+        const [workloadRes, historyRes] = await Promise.all([
+          fetch(`${API_URL}/api/workloads/my`, {
             headers: {
               'Content-Type': 'application/json',
               'x-user': currentUser.username,
             },
           }),
-          fetch(`${import.meta.env.VITE_API_URL}/api/validation-issues/my`, {
+          fetch(`${API_URL}/api/workloads/my/history?years=2`, {
             headers: {
               'Content-Type': 'application/json',
               'x-user': currentUser.username,
@@ -53,16 +80,18 @@ export default function StaffWorkloadPage() {
           throw new Error(workloadErr.message || 'Failed to load workload data.');
         }
 
-        if (!issuesRes.ok) {
-          const issuesErr = await issuesRes.json().catch(() => ({}));
-          throw new Error(issuesErr.message || 'Failed to load validation issues.');
+        if (!historyRes.ok) {
+          const historyErr = await historyRes.json().catch(() => ({}));
+          throw new Error(historyErr.message || 'Failed to load workload history.');
         }
 
         const workloadData = await workloadRes.json();
-        const issuesData = await issuesRes.json();
+        const historyData = await historyRes.json();
 
         setWorkload(workloadData);
-        setIssues(Array.isArray(issuesData) ? issuesData : []);
+        setIssues([]);
+        setHistory(Array.isArray(historyData) ? historyData : []);
+        setSelectedWorkloadKey('current');
       } catch (err) {
         console.error('Failed to load workload page data:', err);
         setError(err.message || 'Unable to load workload data.');
@@ -74,6 +103,47 @@ export default function StaffWorkloadPage() {
     fetchData();
   }, [currentUser]);
 
+useEffect(() => {
+  async function fetchIssuesForSelectedWorkload() {
+    if (!currentUser?.username || !workload) return;
+
+    const selectedWorkload =
+      selectedWorkloadKey === 'current'
+        ? workload
+        : history.find((item) => String(item.id) === String(selectedWorkloadKey)) ||
+          workload;
+
+    if (!selectedWorkload?.importBatchId) {
+      setIssues([]);
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `${API_URL}/api/validation-issues/my?importBatchId=${selectedWorkload.importBatchId}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'x-user': currentUser.username,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message || 'Failed to load validation issues.');
+      }
+
+      const data = await response.json();
+      setIssues(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error('Failed to load validation issues:', err);
+      setIssues([]);
+    }
+  }
+
+  fetchIssuesForSelectedWorkload();
+}, [currentUser, workload, history, selectedWorkloadKey]);
   if (loading) {
     return (
       <div style={{ textAlign: 'center', padding: '40px' }}>
@@ -103,44 +173,72 @@ export default function StaffWorkloadPage() {
     );
   }
 
-  const annualHours = Math.round(ANNUAL_HOURS_PER_FTE * (Number(workload.fte) || 1));
+  const selectedWorkload =
+    selectedWorkloadKey === 'current'
+      ? workload
+      : history.find((item) => String(item.id) === String(selectedWorkloadKey)) ||
+        workload;
+
+  const currentWorkloadYear =
+    workload.workloadYear || new Date().getFullYear();
+
+  const selectedWorkloadYear =
+    selectedWorkload.workloadYear || currentWorkloadYear;
+
+  const annualHours = Math.round(
+    ANNUAL_HOURS_PER_FTE * (Number(selectedWorkload.fte) || 1)
+  );
+
+  const workloadOptions = [
+    {
+      value: 'current',
+      label: `Current workload (${currentWorkloadYear})`,
+    },
+    ...history.map((item) => ({
+      value: String(item.id),
+      label: `Past workload (${item.workloadYear})`,
+    })),
+  ];
 
   const tableData = [
     {
       key: '1',
       category: 'Teaching',
-      percent: workload.teaching ?? 0,
-      hours: calculateHours(workload.teaching, workload.fte),
+      percent: selectedWorkload.teaching ?? 0,
+      hours: calculateHours(selectedWorkload.teaching, selectedWorkload.fte),
     },
     {
       key: '2',
       category: 'HDR Supervision',
-      percent: workload.hdSupervision ?? 0,
-      hours: calculateHours(workload.hdSupervision, workload.fte),
+      percent: selectedWorkload.hdSupervision ?? 0,
+      hours: calculateHours(selectedWorkload.hdSupervision, selectedWorkload.fte),
     },
     {
       key: '3',
       category: 'Research',
-      percent: workload.research ?? 0,
-      hours: calculateHours(workload.research, workload.fte),
+      percent: selectedWorkload.research ?? 0,
+      hours: calculateHours(selectedWorkload.research, selectedWorkload.fte),
     },
     {
       key: '4',
       category: 'Service & Citizenship',
-      percent: workload.service ?? 0,
-      hours: calculateHours(workload.service, workload.fte),
+      percent: selectedWorkload.service ?? 0,
+      hours: calculateHours(selectedWorkload.service, selectedWorkload.fte),
     },
     {
       key: '5',
       category: 'Assigned Roles',
-      percent: workload.assignedRole ?? 0,
-      hours: calculateHours(workload.assignedRole, workload.fte),
+      percent: selectedWorkload.assignedRole ?? 0,
+      hours: calculateHours(selectedWorkload.assignedRole, selectedWorkload.fte),
     },
     {
       key: '6',
       category: 'External Engagement',
-      percent: workload.externalEngagement ?? 0,
-      hours: calculateHours(workload.externalEngagement, workload.fte),
+      percent: selectedWorkload.externalEngagement ?? 0,
+      hours: calculateHours(
+        selectedWorkload.externalEngagement,
+        selectedWorkload.fte
+      ),
     },
   ];
 
@@ -160,12 +258,72 @@ export default function StaffWorkloadPage() {
     },
   ];
 
+  const historyColumns = [
+    {
+      title: 'Year',
+      dataIndex: 'workloadYear',
+      key: 'workloadYear',
+      width: 90,
+      render: (value) => <Text strong>{value || '-'}</Text>,
+    },
+    {
+      title: 'Teaching',
+      dataIndex: 'teaching',
+      key: 'teaching',
+      render: formatPercent,
+    },
+    {
+      title: 'Assigned Roles',
+      dataIndex: 'assignedRole',
+      key: 'assignedRole',
+      render: formatPercent,
+    },
+    {
+      title: 'Service',
+      dataIndex: 'service',
+      key: 'service',
+      render: formatPercent,
+    },
+    {
+      title: 'HDR',
+      dataIndex: 'hdSupervision',
+      key: 'hdSupervision',
+      render: formatPercent,
+    },
+    {
+      title: 'Research',
+      dataIndex: 'research',
+      key: 'research',
+      render: formatPercent,
+    },
+    {
+      title: 'Total',
+      dataIndex: 'total',
+      key: 'total',
+      render: formatPercent,
+    },
+    {
+      title: 'T:R Status',
+      dataIndex: 'hasDiscrepancy',
+      key: 'hasDiscrepancy',
+      render: (value) =>
+        value ? <Tag color="red">Mismatch</Tag> : <Tag color="green">OK</Tag>,
+    },
+    {
+      title: 'Imported',
+      dataIndex: 'importedAt',
+      key: 'importedAt',
+      render: formatDate,
+    },
+  ];
+
   return (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
       <div>
         <Title level={4} style={{ margin: 0 }}>My Workload</Title>
         <Text type="secondary">
-          2026 Academic Year · Estimated on {ANNUAL_HOURS_PER_FTE} hours per 1.0 FTE
+          Current workload: {currentWorkloadYear} Academic Year · Estimated on{' '}
+          {ANNUAL_HOURS_PER_FTE} hours per 1.0 FTE
         </Text>
       </div>
 
@@ -174,7 +332,7 @@ export default function StaffWorkloadPage() {
           type="warning"
           showIcon
           icon={<ExclamationCircleOutlined />}
-          message={`${issues.length} validation issue(s) detected in your workload data.`}
+          message={`${issues.length} validation issue(s) detected in the selected workload data.`}
           description="Please review and submit a query if any allocation is incorrect."
           action={
             <Button size="small" onClick={() => navigate('/staff/queries')}>
@@ -184,20 +342,52 @@ export default function StaffWorkloadPage() {
         />
       )}
 
+      <Card title="View Workload by Year" style={{ marginTop: 16 }}>
+        <Space direction="vertical" size={4}>
+          <Text type="secondary">
+            Select your current workload or one of the previous two workload years.
+          </Text>
+
+          <Select
+            value={selectedWorkloadKey}
+            style={{ width: 300 }}
+            onChange={setSelectedWorkloadKey}
+            options={workloadOptions}
+          />
+        </Space>
+      </Card>
+
       <Card style={{ marginTop: 16 }}>
-        <Descriptions bordered size="small" column={2} title="Staff Information">
-          <Descriptions.Item label="Name">{workload.name}</Descriptions.Item>
-          <Descriptions.Item label="Department">{workload.department}</Descriptions.Item>
-          <Descriptions.Item label="FTE">{workload.fte}</Descriptions.Item>
-          <Descriptions.Item label="Estimated Annual Hours">{annualHours} hrs</Descriptions.Item>
-          <Descriptions.Item label="Total Workload">{workload.total}%</Descriptions.Item>
+        <Descriptions
+          bordered
+          size="small"
+          column={2}
+          title={`Staff Information - ${selectedWorkloadYear}`}
+        >
+          <Descriptions.Item label="Name">{selectedWorkload.name}</Descriptions.Item>
+          <Descriptions.Item label="Department">
+            {selectedWorkload.department}
+          </Descriptions.Item>
+          <Descriptions.Item label="Workload Year">
+            {selectedWorkloadYear}
+          </Descriptions.Item>
+          <Descriptions.Item label="FTE">{selectedWorkload.fte}</Descriptions.Item>
+          <Descriptions.Item label="Estimated Annual Hours">
+            {annualHours} hrs
+          </Descriptions.Item>
+          <Descriptions.Item label="Total Workload">
+            {selectedWorkload.total}%
+          </Descriptions.Item>
           <Descriptions.Item label="Total Allocated Hours">
-            {calculateHours(workload.total, workload.fte)} hrs
+            {calculateHours(selectedWorkload.total, selectedWorkload.fte)} hrs
+          </Descriptions.Item>
+          <Descriptions.Item label="Source File">
+            {selectedWorkload.filename || 'Demo or latest imported workload'}
           </Descriptions.Item>
         </Descriptions>
       </Card>
 
-      <Card title="Workload Breakdown" style={{ marginTop: 16 }}>
+      <Card title={`Workload Breakdown - ${selectedWorkloadYear}`} style={{ marginTop: 16 }}>
         <Table
           columns={columns}
           dataSource={tableData}
@@ -209,14 +399,41 @@ export default function StaffWorkloadPage() {
                 <Text strong>Total</Text>
               </Table.Summary.Cell>
               <Table.Summary.Cell index={1}>
-                <Text strong>{workload.total}%</Text>
+                <Text strong>{selectedWorkload.total}%</Text>
               </Table.Summary.Cell>
               <Table.Summary.Cell index={2}>
-                <Text strong>{calculateHours(workload.total, workload.fte)} hrs</Text>
+                <Text strong>
+                  {calculateHours(selectedWorkload.total, selectedWorkload.fte)} hrs
+                </Text>
               </Table.Summary.Cell>
             </Table.Summary.Row>
           )}
         />
+      </Card>
+
+      <Card
+        title="Past Workload History"
+        extra={<Text type="secondary">Previous two workload years</Text>}
+        style={{ marginTop: 16 }}
+      >
+        {history.length === 0 ? (
+          <Alert
+            type="info"
+            showIcon
+            message="No past workload history found yet."
+            description="Historical records will appear here after previous-year workload spreadsheets are imported."
+          />
+        ) : (
+          <Table
+            rowKey={(record) =>
+              `${record.workloadYear}-${record.importBatchId}-${record.staffId}`
+            }
+            columns={historyColumns}
+            dataSource={history}
+            pagination={false}
+            scroll={{ x: 1000 }}
+          />
+        )}
       </Card>
 
       {issues.length > 0 && (


### PR DESCRIPTION
## Summary

This PR updates the workload verification system so HoS and School Operations can view workload data by selected workload year, instead of always seeing the latest import.

It also prepares the system for a cleaner demonstration workflow by ensuring the system starts fresh and workload data is created through Excel imports.

## Changes Made

- Added backend support for `workloadYear` query parameters on workload and import report routes.
- Updated workload retrieval so HoS/Ops can view 2024, 2025, or 2026 data separately.
- Updated import report logic so the selected report year controls the displayed summary, validation issues, and workload records.
- Added a separate “View Import Report” year selector on the Import Data page.
- Updated School Workload page so changing the workload year reloads the correct data.
- Kept the upload workload year selector separate from the report year selector to avoid confusing UI behaviour.
- Updated staff workload history so staff can view the current workload and previous two workload years.
- Removed seeded workload/query demo data from fresh setup so workload data comes from imported Excel files.

## Testing

- Reset local database and confirmed the system starts fresh.
- Confirmed seeded users still allow login.
- Imported 2024, 2025, and 2026 workload files from scratch.
- Tested `/api/workloads?workloadYear=2024`, `/api/workloads?workloadYear=2025`, and `/api/workloads?workloadYear=2026`.
- Confirmed School Workload page changes data when selecting different years.
- Confirmed Import Data report changes summary/issues/workloads when selecting different years.
- Confirmed staff account shows current workload plus previous two years.
- Confirmed validation issues are shown for the selected workload/import batch.