### PR TITLE
Fix report PDF export

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@ant-design/icons": "^6.1.1",
         "antd": "^6.3.4",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^4.2.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.2",
@@ -2708,6 +2710,19 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2725,6 +2740,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -3086,6 +3108,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
@@ -3189,6 +3220,26 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/cfb": {
       "version": "1.2.2",
@@ -3308,6 +3359,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -3331,6 +3394,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -3480,6 +3552,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",
@@ -3782,6 +3864,17 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3798,6 +3891,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3938,6 +4037,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4022,6 +4134,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -4168,6 +4286,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -4611,6 +4746,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4670,6 +4811,13 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4773,6 +4921,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -4847,6 +5005,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4864,6 +5029,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rolldown": {
@@ -5059,6 +5234,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
@@ -5126,12 +5311,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/throttle-debounce": {
       "version": "5.0.2",
@@ -5293,6 +5497,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@ant-design/icons": "^6.1.1",
     "antd": "^6.3.4",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^4.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.2",

--- a/frontend/src/pages/admin/ReportsPage.jsx
+++ b/frontend/src/pages/admin/ReportsPage.jsx
@@ -1,14 +1,58 @@
-import { useState, useEffect } from 'react';
-import { Card, Table, Typography, Space, Button, Divider, Spin, Alert } from 'antd';
+import { useState, useEffect, useMemo, useRef } from 'react';
+import {
+  Card,
+  Table,
+  Typography,
+  Space,
+  Button,
+  Divider,
+  Spin,
+  Alert,
+  Select,
+  message,
+} from 'antd';
 import { DownloadOutlined } from '@ant-design/icons';
+import html2canvas from 'html2canvas';
+import { jsPDF } from 'jspdf';
 import { useAuth } from '../../context/AuthContext';
 
 const { Title, Text } = Typography;
 
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+const ANNUAL_HOURS_PER_FTE = 1600;
+
+function calculateHours(percent, fte = 1) {
+  return Math.round(
+    ((Number(percent) || 0) / 100) *
+      ANNUAL_HOURS_PER_FTE *
+      (Number(fte) || 1)
+  );
+}
+
 export default function ReportsPage() {
   const { currentUser } = useAuth();
+  const reportRef = useRef(null);
 
+  const currentYear = new Date().getFullYear();
+
+  const yearOptions = useMemo(
+    () =>
+      [
+        currentYear,
+        currentYear - 1,
+        currentYear - 2,
+        currentYear - 3,
+        currentYear - 4,
+      ].map((year) => ({
+        label: `${year} workload`,
+        value: year,
+      })),
+    [currentYear]
+  );
+
+  const [selectedYear, setSelectedYear] = useState(currentYear);
   const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
   const [workload, setWorkload] = useState([]);
   const [error, setError] = useState('');
 
@@ -24,12 +68,23 @@ export default function ReportsPage() {
       setError('');
 
       try {
-        const response = await fetch(`${import.meta.env.VITE_API_URL}/api/workloads`, {
-          headers: {
-            'Content-Type': 'application/json',
-            'x-user': currentUser.username,
-          },
-        });
+        const response = await fetch(
+          `${API_URL}/api/workloads?workloadYear=${selectedYear}`,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              'x-user': currentUser.username,
+            },
+          }
+        );
+
+        const contentType = response.headers.get('content-type') || '';
+
+        if (!contentType.includes('application/json')) {
+          throw new Error(
+            'Backend did not return JSON. Please check that the backend is running on http://localhost:5000.'
+          );
+        }
 
         const data = await response.json();
 
@@ -47,68 +102,283 @@ export default function ReportsPage() {
     };
 
     fetchReportData();
-  }, [currentUser]);
+  }, [currentUser, selectedYear]);
 
   const summaryColumns = [
-    { title: 'Staff Member', dataIndex: 'name', key: 'name' },
-    { title: 'Department', dataIndex: 'department', key: 'department' },
-    { title: 'FTE', dataIndex: 'fte', key: 'fte', width: 70 },
-    { title: 'Teaching (%)', dataIndex: 'teaching', key: 'teaching', render: (v) => `${v}%` },
-    { title: 'HDR (%)', dataIndex: 'hdSupervision', key: 'hdSupervision', render: (v) => `${v}%` },
-    { title: 'Research (%)', dataIndex: 'research', key: 'research', render: (v) => `${v}%` },
-    { title: 'Service (%)', dataIndex: 'service', key: 'service', render: (v) => `${v}%` },
-    { title: 'Roles (%)', dataIndex: 'assignedRole', key: 'assignedRole', render: (v) => `${v}%` },
-    { title: 'Total (%)', dataIndex: 'total', key: 'total', render: (v) => <Text strong>{v}%</Text> },
+    {
+      title: 'Staff Member',
+      dataIndex: 'name',
+      key: 'name',
+      width: 190,
+    },
+    {
+      title: 'Department',
+      dataIndex: 'department',
+      key: 'department',
+      width: 130,
+    },
+    {
+      title: 'FTE',
+      dataIndex: 'fte',
+      key: 'fte',
+      width: 70,
+    },
+    {
+      title: 'Teaching',
+      key: 'teaching',
+      render: (_, record) => (
+        <>
+          <Text>{record.teaching}%</Text>
+          <br />
+          <Text type="secondary">
+            {calculateHours(record.teaching, record.fte)} hrs
+          </Text>
+        </>
+      ),
+    },
+    {
+      title: 'HDR',
+      key: 'hdSupervision',
+      render: (_, record) => (
+        <>
+          <Text>{record.hdSupervision}%</Text>
+          <br />
+          <Text type="secondary">
+            {calculateHours(record.hdSupervision, record.fte)} hrs
+          </Text>
+        </>
+      ),
+    },
+    {
+      title: 'Research',
+      key: 'research',
+      render: (_, record) => (
+        <>
+          <Text>{record.research}%</Text>
+          <br />
+          <Text type="secondary">
+            {calculateHours(record.research, record.fte)} hrs
+          </Text>
+        </>
+      ),
+    },
+    {
+      title: 'Service',
+      key: 'service',
+      render: (_, record) => (
+        <>
+          <Text>{record.service}%</Text>
+          <br />
+          <Text type="secondary">
+            {calculateHours(record.service, record.fte)} hrs
+          </Text>
+        </>
+      ),
+    },
+    {
+      title: 'Roles',
+      key: 'assignedRole',
+      render: (_, record) => (
+        <>
+          <Text>{record.assignedRole}%</Text>
+          <br />
+          <Text type="secondary">
+            {calculateHours(record.assignedRole, record.fte)} hrs
+          </Text>
+        </>
+      ),
+    },
+    {
+      title: 'Total',
+      dataIndex: 'total',
+      key: 'total',
+      render: (value) => <Text strong>{value}%</Text>,
+    },
   ];
 
-  function handleExportPDF() {
-    window.print();
+  async function handleExportPDF() {
+    if (!reportRef.current) {
+      message.error('Report content was not found.');
+      return;
+    }
+
+    if (workload.length === 0) {
+      message.warning('There is no report data to export.');
+      return;
+    }
+
+    try {
+      setExporting(true);
+
+      const canvas = await html2canvas(reportRef.current, {
+        scale: 2,
+        useCORS: true,
+        backgroundColor: '#ffffff',
+        scrollX: 0,
+        scrollY: -window.scrollY,
+      });
+
+      const imageData = canvas.toDataURL('image/png');
+
+      const pdf = new jsPDF({
+        orientation: 'landscape',
+        unit: 'mm',
+        format: 'a4',
+      });
+
+      const pageWidth = pdf.internal.pageSize.getWidth();
+      const pageHeight = pdf.internal.pageSize.getHeight();
+
+      const margin = 8;
+      const usableWidth = pageWidth - margin * 2;
+      const imageHeight = (canvas.height * usableWidth) / canvas.width;
+
+      let heightLeft = imageHeight;
+      let position = margin;
+
+      pdf.addImage(imageData, 'PNG', margin, position, usableWidth, imageHeight);
+      heightLeft -= pageHeight - margin * 2;
+
+      while (heightLeft > 0) {
+        pdf.addPage();
+        position = heightLeft - imageHeight + margin;
+        pdf.addImage(imageData, 'PNG', margin, position, usableWidth, imageHeight);
+        heightLeft -= pageHeight - margin * 2;
+      }
+
+      pdf.save(`workload-summary-report-${selectedYear}.pdf`);
+      message.success('PDF exported successfully.');
+    } catch (error) {
+      console.error('PDF export failed:', error);
+      message.error('PDF export failed. Please try again.');
+    } finally {
+      setExporting(false);
+    }
   }
 
   if (loading) {
     return (
       <div style={{ display: 'flex', justifyContent: 'center', padding: '100px' }}>
-        <Spin size="large" tip="Generating report..." />
+        <Spin size="large" description="Generating report..." />
       </div>
     );
   }
 
   if (error) {
-    return <Alert message="Unable to load report" description={error} type="error" showIcon />;
+    return (
+      <Alert
+        message="Unable to load report"
+        description={error}
+        type="error"
+        showIcon
+      />
+    );
   }
+
+  const avgTotal = workload.length
+    ? (
+        workload.reduce((sum, record) => sum + Number(record.total || 0), 0) /
+        workload.length
+      ).toFixed(1)
+    : 0;
+
+  const discrepancyCount = workload.filter((record) => record.hasDiscrepancy).length;
 
   return (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-end',
+          gap: 16,
+          flexWrap: 'wrap',
+        }}
+      >
         <div>
-          <Title level={4} style={{ margin: 0 }}>Workload Summary Report</Title>
-          <Text type="secondary">2026 Academic Year · PMC School</Text>
+          <Title level={4} style={{ margin: 0 }}>
+            Workload Summary Report
+          </Title>
+          <Text type="secondary">
+            {selectedYear} Academic Year · PMC School
+          </Text>
         </div>
 
-        <Button icon={<DownloadOutlined />} onClick={handleExportPDF}>
-          Export PDF
-        </Button>
+        <Space>
+          <div>
+            <Text type="secondary">Workload year</Text>
+            <br />
+            <Select
+              value={selectedYear}
+              options={yearOptions}
+              onChange={setSelectedYear}
+              style={{ width: 180 }}
+            />
+          </div>
+
+          <Button
+            icon={<DownloadOutlined />}
+            onClick={handleExportPDF}
+            loading={exporting}
+          >
+            Export PDF
+          </Button>
+        </Space>
       </div>
 
-      <Card id="report-content">
-        <div style={{ marginBottom: 16 }}>
-          <Text strong>School: </Text>
-          <Text>PMC (Physics, Maths, Computer Science)</Text>
-          <Divider style={{ margin: '12px 0' }} />
-        </div>
+      {workload.length === 0 && (
+        <Alert
+          type="info"
+          showIcon
+          message={`No report data found for ${selectedYear}.`}
+          description="Upload a workload spreadsheet for this year from the Import Data page."
+        />
+      )}
 
-        <Table
-          columns={summaryColumns}
-          dataSource={workload}
-          rowKey="staffId"
-          pagination={false}
-          size="middle"
-          summary={(data) => {
-            const avgTotal = data.length
-              ? (data.reduce((s, r) => s + r.total, 0) / data.length).toFixed(1)
-              : 0;
+      <Card>
+        <div
+          id="report-content"
+          ref={reportRef}
+          style={{
+            background: '#ffffff',
+            padding: 24,
+          }}
+        >
+          <div style={{ marginBottom: 16 }}>
+            <Title level={4} style={{ marginBottom: 4 }}>
+              Workload Summary Report
+            </Title>
 
-            return (
+            <Text strong>School: </Text>
+            <Text>PMC (Physics, Maths, Computer Science)</Text>
+            <br />
+
+            <Text strong>Academic Year: </Text>
+            <Text>{selectedYear}</Text>
+            <br />
+
+            <Text strong>Total Staff Records: </Text>
+            <Text>{workload.length}</Text>
+            <br />
+
+            <Text strong>T:R Discrepancies: </Text>
+            <Text>{discrepancyCount}</Text>
+            <br />
+
+            <Text strong>Average Total Workload: </Text>
+            <Text>{avgTotal}%</Text>
+
+            <Divider style={{ margin: '12px 0' }} />
+          </div>
+
+          <Table
+            columns={summaryColumns}
+            dataSource={workload}
+            rowKey={(record) => `${record.importBatchId || 'demo'}-${record.staffId}`}
+            pagination={false}
+            size="middle"
+            scroll={{ x: 1200 }}
+            summary={() => (
               <Table.Summary.Row>
                 <Table.Summary.Cell index={0} colSpan={8}>
                   <Text strong>School Average Total Workload</Text>
@@ -117,9 +387,9 @@ export default function ReportsPage() {
                   <Text strong>{avgTotal}%</Text>
                 </Table.Summary.Cell>
               </Table.Summary.Row>
-            );
-          }}
-        />
+            )}
+          />
+        </div>
       </Card>
     </Space>
   );


### PR DESCRIPTION
## Summary

This PR fixes the report PDF export functionality for the HoS and School Operations report page.

## Changes Made

- Replaced the old `window.print()` export approach with a proper PDF export using `html2canvas` and `jsPDF`.
- Added workload year selection to the Reports page so reports can be generated for 2024, 2025, or 2026.
- Updated the report fetch request to use the selected workload year.
- Added PDF export loading state and user feedback messages.
- Added checks to prevent exporting when no report data is available.
- Improved the exported report content by including:
  - Academic year
  - School name
  - Total staff records
  - T:R discrepancy count
  - Average total workload
  - Full workload summary table

## Testing

- Tested Reports page as HoS/School Operations.
- Confirmed workload report loads correctly for selected workload years.
- Confirmed Export PDF button downloads a PDF file successfully.
- Confirmed exported filename includes the selected workload year.
- Confirmed empty report data does not export and shows a warning message.